### PR TITLE
Define CORTEX imported catalog mapping

### DIFF
--- a/README.md
+++ b/README.md
@@ -41,6 +41,13 @@ See [docs/character-ara-doctrine.md](docs/character-ara-doctrine.md) for the cha
 - [docs/ascent-integration-contract.md](docs/ascent-integration-contract.md): bounded `ASCENT -> CORTEX` contract for progression state, rewards, penalties, and achievement inputs for `CORTEX #11`
 - [docs/runtime-topology.md](docs/runtime-topology.md): native-first runtime topology for child programs, host roles, and explicit bridge boundaries for `CORTEX #7`
 - [docs/packaging-distribution-model.md](docs/packaging-distribution-model.md): native-first packaging, distribution, and artifact compatibility model for `CORTEX #8`
+- [docs/imported-catalog-mapping.md](docs/imported-catalog-mapping.md): imported helper/subagent catalog mapping contract, template and overlay contracts, lifecycle ownership, error behavior, compatibility policy, and example mappings for `CORTEX #9`
 - [docs/external-integration-contract.md](docs/external-integration-contract.md): governed export and registration contract for `VECTOR`, `NEXUS`, and external execution targets for `CORTEX #3`
 - [docs/character-management-ui-contract.md](docs/character-management-ui-contract.md): thin-host creation and management surface contract for `CORTEX #10`
 - [prototypes/cortex-control-surface.html](prototypes/cortex-control-surface.html): visual prototype for the control surface, current execution wave, and progress visibility surface
+
+## Current execution status
+
+- `CORTEX #3`: Done
+- `CORTEX #9`: Active (imported helper/subagent mapping contract)
+- `CORTEX #2`: In Progress (execution sequencing and PRISM wave entry)

--- a/docs/character-management-ui-contract.md
+++ b/docs/character-management-ui-contract.md
@@ -121,5 +121,5 @@ Each error should show:
 3. The operator attaches a PRISM stylization input and an ASCENT progression input.
 4. The Component Inspector shows current owner, provenance aliases, and 3/12 subagent capacity on the active slot.
 5. The Lifecycle Console exposes validate and mark_ready because those are the only native-legal actions.
-6. The Execution Wave Rail shows the first-wave set complete, #3 active as the current integration lane, and #9 queued as the next follow-on mapping lane.
+6. The Execution Wave Rail shows the first-wave set complete, #3 done as the integration lane, and #9 active as the imported-catalog mapping lane.
 ```

--- a/docs/imported-catalog-mapping.md
+++ b/docs/imported-catalog-mapping.md
@@ -1,0 +1,173 @@
+# CORTEX Imported Catalog Mapping Contract
+
+Issue alignment: `CORTEX #9`
+
+## Purpose
+
+Define how imported external subagent catalog entries map into CORTEX helper definitions, array templates, character overlays, and lifecycle ownership without promoting imported records into persistent identities by default.
+
+This contract depends on the canonical entity model in [`canonical-entity-model.md`](./canonical-entity-model.md) and the external boundary in [`external-integration-contract.md`](./external-integration-contract.md). It narrows the follow-on mapping lane after `CORTEX #3`.
+
+## Interface contract
+
+The imported catalog mapper must classify each accepted catalog entry into exactly one governed CORTEX surface:
+
+- `ImportedHelperSubagentDefinition`: a definition-only helper template that can be staged or instantiated by an eligible `AraComponent`
+- `ImportedArrayTemplate`: an imported ARA pattern that can seed component layout, role defaults, and helper placement without becoming a character
+- `ImportedCharacterOverlay`: a bounded presentation or behavior overlay that can attach to a `Character` without replacing CORTEX ownership, lifecycle, or canonical labels
+
+The mapper may return a quarantine result when the catalog entry has valid provenance but cannot be safely classified yet. It must reject entries that try to become `Symbiote`, `Curator`, `Character`, or lifecycle authority records by implication.
+
+## Expected inputs and outputs
+
+Inputs:
+
+- `CortexCatalogRegistration` records accepted by the external integration boundary
+- imported source provenance: `source_repo`, `source_path`, `source_commit`, and optional `source_manifest_ref`
+- runtime classification hints such as `runtime_class`, `host_targets[]`, `array_binding_policy`, and `overlay_ref`
+- native CORTEX owner, component, and lifecycle descriptors used to validate binding eligibility
+
+Outputs:
+
+- normalized `ImportedHelperSubagentDefinition`, `ImportedArrayTemplate`, or `ImportedCharacterOverlay` descriptors
+- inert quarantine descriptors for known-but-unsupported classes
+- validation results that state accepted, narrowed, quarantined, or rejected
+- audit metadata that links each mapped descriptor back to its source catalog registration and CORTEX lifecycle decision
+
+## Mapping rules
+
+### `ImportedHelperSubagentDefinition`
+
+Use this surface when an imported entry describes one helper capability that can be staged under exactly one `AraComponent`.
+
+Required descriptor fields:
+
+- `definition_id`
+- `canonical_label`
+- `provenance_aliases[]`
+- `source_registration_ref`
+- `runtime_class`
+- `host_targets[]`
+- `compatible_component_roles[]`
+- `allowed_input_contracts[]`
+- `declared_output_contracts[]`
+- `promotion_policy`
+- `compatibility_version`
+
+Rules:
+
+- helper definitions remain definition-only until a native CORTEX bind or spawn action creates a `SubagentInstance`
+- helper definitions may not increase the per-component subagent ceiling beyond `12`
+- helper labels may expose provenance aliases, but CORTEX canonical labels remain the default display label
+- helper host-target support is descriptive and never self-authorizing
+
+### `ImportedArrayTemplate`
+
+Use this surface when an imported entry describes a reusable component layout or helper-placement pattern.
+
+Required descriptor fields:
+
+- `template_id`
+- `canonical_label`
+- `source_registration_ref`
+- `array_shape`
+- `component_role_defaults[]`
+- `helper_definition_refs[]`
+- `owner_binding_policy`
+- `lifecycle_gate_policy`
+- `compatibility_version`
+
+Rules:
+
+- two-component and three-component templates are first-class
+- larger templates require an explicit native construction rule or operator justification
+- templates may seed construction, but the resulting `Character` and `AraComponent` records are still CORTEX-owned
+- templates may suggest component roles, but they may not override owner resolution or lifecycle gates
+
+### `ImportedCharacterOverlay`
+
+Use this surface when an imported entry describes presentation, bounded behavior, or governance metadata attached to an existing character.
+
+Required descriptor fields:
+
+- `overlay_id`
+- `canonical_label`
+- `source_registration_ref`
+- `target_character_policy`
+- `overlay_kind`
+- `allowed_attachment_points[]`
+- `blocked_authority_claims[]`
+- `prism_compatibility_ref?`
+- `compatibility_version`
+
+Rules:
+
+- overlays may modify presentation or bounded behavior only
+- overlays may not replace character ownership, lifecycle state, canonical labels, or ARA component authority
+- overlays that affect personality or stylization must include `prism_compatibility_ref` and remain compatible with the `PRISM -> CORTEX` boundary
+- overlays with unresolved target policies remain staged or quarantined
+
+## Lifecycle ownership
+
+- imported descriptors start as `staged`
+- descriptors move to `validated` only after provenance, compatibility, and authority checks pass
+- descriptors move to `bound` only when attached to an eligible character or component by a native CORTEX action
+- helper definitions create `active` runtime behavior only through a `SubagentInstance`
+- descriptors move to `retired` without deleting provenance or audit metadata
+
+CORTEX owns lifecycle state after import. Source repositories own the source catalog content, but they do not own CORTEX binding, promotion, activation, or retirement decisions.
+
+## Validation rules
+
+- every imported descriptor must resolve to a known `CortexCatalogRegistration`
+- exactly one target surface must be selected for each accepted descriptor
+- unresolved source provenance must reject the mapping
+- unknown runtime classes must be quarantined or rejected, not silently narrowed
+- helper definitions must name at least one compatible component role
+- array templates must provide a valid array shape and non-conflicting component role defaults
+- overlays must declare blocked authority claims and fail if they try to replace identity, owner, lifecycle, or label authority
+- binding must fail if the target component would exceed its subagent ceiling
+
+## Error behavior
+
+Stable native error families for imported mapping:
+
+- `CORTEX_ERR_IMPORT_PROVENANCE_INVALID`
+- `CORTEX_ERR_IMPORT_CLASS_UNSUPPORTED`
+- `CORTEX_ERR_IMPORT_SURFACE_AMBIGUOUS`
+- `CORTEX_ERR_IMPORT_REFERENCE_UNRESOLVED`
+- `CORTEX_ERR_IMPORT_ARRAY_POLICY_INVALID`
+- `CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION`
+- `CORTEX_ERR_IMPORT_COMPONENT_INCOMPATIBLE`
+- `CORTEX_ERR_IMPORT_PROMOTION_REQUIRED`
+
+Each failure should report:
+
+- imported descriptor id
+- source registration id
+- selected or attempted target surface
+- failing rule id
+- whether the descriptor was rejected or quarantined
+- operator-fixable remediation when narrowing can recover the mapping
+
+Mapping failures must not partially mutate characters, components, subagent instances, overlays, or lifecycle state.
+
+## Compatibility and versioning notes
+
+- descriptor versions are additive by default
+- existing field meanings must not be reassigned across versions
+- unknown descriptor versions should be quarantined until a native mapper can classify them
+- `compatibility_version` belongs to the mapped CORTEX descriptor; source package versions remain provenance data
+- future runtime implementation should expose mapper and descriptor versions through the stable C ABI
+
+## Example usage
+
+```text
+1. CORTEX receives a CortexCatalogRegistration for an external helper from SYMBIOSIS with source_repo, source_path, and source_commit populated.
+2. The mapper classifies runtime_class=helper as ImportedHelperSubagentDefinition and validates host_targets against the external integration contract.
+3. The descriptor stays staged until provenance and compatibility checks pass.
+4. A two-component ImportedArrayTemplate references the helper for the active component role.
+5. The operator creates a Character from the template; CORTEX creates native AraComponent records and keeps ownership in CORTEX.
+6. The helper becomes runtime-active only after CORTEX binds it as a SubagentInstance under one eligible component.
+7. If an overlay tries to replace the character owner, CORTEX rejects it with CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION.
+```

--- a/prototypes/cortex-control-surface.html
+++ b/prototypes/cortex-control-surface.html
@@ -13,6 +13,8 @@
       --accent: #ff8a3d;
       --accent-soft: rgba(255, 138, 61, 0.18);
       --glow: #46d2ba;
+      --template: #8db7ff;
+      --overlay: #ff77a8;
       --warning: #ffc857;
       --done: #7de07d;
       --bg-top: #31160f;
@@ -304,11 +306,27 @@
       background: linear-gradient(145deg, rgba(255, 255, 255, 0.05), rgba(255, 255, 255, 0.03));
     }
 
+    .slot.import-helper {
+      border-color: rgba(70, 210, 186, 0.48);
+      background: linear-gradient(145deg, rgba(70, 210, 186, 0.11), rgba(255, 255, 255, 0.03));
+    }
+
+    .slot.import-template {
+      border-color: rgba(141, 183, 255, 0.5);
+      background: linear-gradient(145deg, rgba(141, 183, 255, 0.12), rgba(255, 255, 255, 0.03));
+    }
+
+    .slot.import-overlay {
+      border-color: rgba(255, 119, 168, 0.5);
+      background: linear-gradient(145deg, rgba(255, 119, 168, 0.12), rgba(255, 255, 255, 0.03));
+    }
+
     .slot-header {
       display: flex;
       justify-content: space-between;
       align-items: center;
       gap: 0.75rem;
+      flex-wrap: wrap;
     }
 
     .badge {
@@ -321,6 +339,33 @@
       color: var(--accent);
       font-family: "Bahnschrift", "Trebuchet MS", sans-serif;
       font-size: 0.72rem;
+    }
+
+    .surface-chip {
+      display: inline-flex;
+      align-items: center;
+      width: max-content;
+      padding: 0.24rem 0.58rem;
+      border-radius: 999px;
+      font-family: "Bahnschrift", "Trebuchet MS", sans-serif;
+      font-size: 0.72rem;
+      letter-spacing: 0.06em;
+      text-transform: uppercase;
+    }
+
+    .surface-chip.helper {
+      color: #0b302a;
+      background: rgba(70, 210, 186, 0.92);
+    }
+
+    .surface-chip.template {
+      color: #081e44;
+      background: rgba(141, 183, 255, 0.92);
+    }
+
+    .surface-chip.overlay {
+      color: #3b1021;
+      background: rgba(255, 119, 168, 0.92);
     }
 
     .subagent-bar {
@@ -403,6 +448,8 @@
     }
 
     .dot.glow { background: var(--glow); }
+    .dot.template { background: var(--template); }
+    .dot.overlay { background: var(--overlay); }
     .dot.warn { background: var(--warning); }
     .dot.done { background: var(--done); }
 
@@ -430,16 +477,16 @@
       </div>
         <div class="hero-metrics">
           <div class="metric">
-            <strong>#3 Active</strong>
-            <span>External integration is the live execution head now that the first-wave packaging lane is complete.</span>
+            <strong>#9 Active</strong>
+            <span>Imported catalog mapping is the live execution head for governed helper, template, and overlay intake.</span>
           </div>
           <div class="metric">
-            <strong>#9 Next</strong>
-            <span>Imported catalog mapping follows once the top-level external boundary is explicit.</span>
+            <strong>#3 Done</strong>
+            <span>VECTOR, NEXUS, and external execution boundaries are landed and ready for follow-on mapping work.</span>
           </div>
           <div class="metric">
-            <strong>7 / 7 Wave Done</strong>
-            <span>The first-wave execution set is complete and the project has moved into follow-on integration work.</span>
+            <strong>8 / 8 Contracts Done</strong>
+            <span>The first-wave contract set is complete; #9 now turns those contracts into imported-catalog ownership rules.</span>
           </div>
           <div class="metric">
             <strong>30% Product Ready</strong>
@@ -454,7 +501,7 @@
           <div class="progress-track" aria-label="Execution wave progress">
             <span class="progress-fill" style="width: 100%;"></span>
           </div>
-          <p>Done: #6, #5, #10, #4, #11, #7, #8. Active: #3. Next: #9.</p>
+          <p>Done: #6, #5, #10, #4, #11, #7, #8, #3. Active: #9 imported catalog mapping.</p>
         </div>
     </section>
 
@@ -492,17 +539,17 @@
             <div class="status-tag done">Done</div>
             <p>Progression enters as governed input, not character-construction authority.</p>
           </div>
-          <div class="wave-card current">
+          <div class="wave-card">
             <div class="issue">Issue #3</div>
             <strong>External integration</strong>
-            <div class="status-tag active">Active</div>
-            <p>VECTOR, NEXUS, and external execution targets are the current lane now that packaging identity is explicit.</p>
+            <div class="status-tag done">Done</div>
+            <p>VECTOR, NEXUS, and external execution targets are bounded so imported definitions can enter governed CORTEX surfaces.</p>
           </div>
-          <div class="wave-card next">
+          <div class="wave-card current">
             <div class="issue">Issue #9</div>
             <strong>Catalog mapping</strong>
-            <div class="status-tag queued">Queued</div>
-            <p>Imported external subagent definitions map into governed helper, template, overlay, and lifecycle surfaces after the top-level contract lands.</p>
+            <div class="status-tag active">Active</div>
+            <p>Imported external subagent definitions now map into governed helper, template, overlay, and lifecycle ownership surfaces.</p>
           </div>
         </div>
       </article>
@@ -517,7 +564,9 @@
         <div class="legend">
           <span><i class="dot done"></i> Completed lane</span>
           <span><i class="dot"></i> Current lane</span>
-          <span><i class="dot glow"></i> Native-legal action</span>
+          <span><i class="dot glow"></i> Imported helper / native-legal action</span>
+          <span><i class="dot template"></i> Imported array template</span>
+          <span><i class="dot overlay"></i> Imported character overlay</span>
           <span><i class="dot warn"></i> Capacity or governance warning</span>
         </div>
       </article>
@@ -543,11 +592,11 @@
           </div>
           <div class="io-card">
             <strong>Project visibility</strong>
-            <p>The execution wave stays read-only, shows done or active or queued state, and distinguishes first-wave planning progress from overall product readiness.</p>
+            <p>The execution wave stays read-only, shows done or active state, and distinguishes first-wave planning progress from imported-catalog mapping work.</p>
           </div>
           <div class="io-card">
             <strong>Project pulse</strong>
-            <p>PR #16 is merged, the first-wave plan is complete, #3 is active, and the product is still early overall despite stronger architectural coverage.</p>
+            <p>Issue #3 is done, the first-wave contract set is complete, #9 is active, and the product is still early overall despite stronger architectural coverage.</p>
           </div>
         </div>
       </article>
@@ -560,13 +609,19 @@
         {
           role: "Active",
           owner: "Primary Symbiote",
-          provenance: "Canonical label default, 2 provenance aliases attached",
+          surface: "Imported helper",
+          surfaceClass: "import-helper",
+          surfaceKind: "helper",
+          provenance: "Imported helper definitions mapped, native promotion still gated",
           subagents: "4 / 12 subagents governed",
           fill: "33%"
         },
         {
           role: "Memory",
           owner: "Curator-supervised",
+          surface: "Character overlay",
+          surfaceClass: "import-overlay",
+          surfaceKind: "overlay",
           provenance: "Imported overlay staged, no promotion",
           subagents: "2 / 12 subagents governed",
           fill: "16%"
@@ -576,13 +631,19 @@
         {
           role: "Active",
           owner: "Primary Symbiote",
-          provenance: "Built-in helper template bound",
+          surface: "Imported helper",
+          surfaceClass: "import-helper",
+          surfaceKind: "helper",
+          provenance: "Imported helper definitions mapped, native promotion still gated",
           subagents: "4 / 12 subagents governed",
           fill: "33%"
         },
         {
           role: "Memory",
           owner: "Curator-supervised",
+          surface: "Character overlay",
+          surfaceClass: "import-overlay",
+          surfaceKind: "overlay",
           provenance: "Imported overlay staged, no promotion",
           subagents: "2 / 12 subagents governed",
           fill: "16%"
@@ -590,7 +651,10 @@
         {
           role: "Reasoning",
           owner: "Primary Symbiote",
-          provenance: "Imported helper definitions queued",
+          surface: "Array template",
+          surfaceClass: "import-template",
+          surfaceKind: "template",
+          provenance: "Imported array template bound to reasoning capacity policy",
           subagents: "3 / 12 subagents governed",
           fill: "25%"
         }
@@ -604,12 +668,13 @@
       slots.innerHTML = "";
       slotSets[flow].forEach((slot, index) => {
         const article = document.createElement("article");
-        article.className = "slot";
+        article.className = `slot ${slot.surfaceClass}`;
         article.innerHTML = `
           <div class="slot-header">
             <strong>${index + 1}. ${slot.role} Component</strong>
             <span class="badge">${slot.owner}</span>
           </div>
+          <span class="surface-chip ${slot.surfaceKind}">${slot.surface}</span>
           <div>${slot.provenance}</div>
           <div>${slot.subagents}</div>
           <div class="subagent-bar" style="--fill:${slot.fill}"></div>


### PR DESCRIPTION
## Summary
- add the native-first imported catalog mapping contract for CORTEX#9
- index the new contract in README and refresh execution status so #3 is Done, #9 is Active, and #2 remains the sequencing lane
- update the UI contract/prototype so imported helpers, array templates, and character overlays are visually distinct and governed

## Verification
- git diff --check HEAD~1 HEAD
- scoped stale-string check for #3 Active, #9 Next, Active: #3, #9 queued, prism_binding_ref
- static prototype HTML tag-balance check was performed locally before PR creation

Browser render was not run because no local browser command was available on this host.

Closes follow-on scope for CORTEX#9 pending review.