### PR TITLE
Implement native imported catalog mapper

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -1,0 +1,40 @@
+cmake_minimum_required(VERSION 3.20)
+
+project(CORTEX
+  VERSION 0.1.0
+  DESCRIPTION "Native CORTEX runtime components"
+  LANGUAGES C)
+
+set(CMAKE_C_STANDARD 11)
+set(CMAKE_C_STANDARD_REQUIRED ON)
+set(CMAKE_C_EXTENSIONS OFF)
+
+add_library(cortex_imported_catalog_mapper STATIC
+  src/imported_catalog_mapper.c)
+
+target_include_directories(cortex_imported_catalog_mapper
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+if(MSVC)
+  target_compile_options(cortex_imported_catalog_mapper PRIVATE /W4 /permissive-)
+else()
+  target_compile_options(cortex_imported_catalog_mapper PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+enable_testing()
+
+add_executable(cortex_imported_catalog_mapper_tests
+  tests/test_imported_catalog_mapper.c)
+
+target_link_libraries(cortex_imported_catalog_mapper_tests
+  PRIVATE cortex_imported_catalog_mapper)
+
+if(MSVC)
+  target_compile_options(cortex_imported_catalog_mapper_tests PRIVATE /W4 /permissive-)
+else()
+  target_compile_options(cortex_imported_catalog_mapper_tests PRIVATE -Wall -Wextra -Wpedantic)
+endif()
+
+add_test(NAME cortex_imported_catalog_mapper_tests
+  COMMAND cortex_imported_catalog_mapper_tests)

--- a/README.md
+++ b/README.md
@@ -33,6 +33,18 @@ The native core owns character modeling, ARA behavior, lifecycle control, subage
 
 See [docs/character-ara-doctrine.md](docs/character-ara-doctrine.md) for the character model and [docs/native-c-avalonia-direction.md](docs/native-c-avalonia-direction.md) for the stack rule and packaging implications.
 
+## Native runtime slice
+
+The first native C runtime slice is the imported catalog mapper for `CORTEX #19`.
+
+```powershell
+cmake -S . -B "$env:LOCALAPPDATA\CORTEX\imported-catalog-build"
+cmake --build "$env:LOCALAPPDATA\CORTEX\imported-catalog-build" --config Debug
+ctest --test-dir "$env:LOCALAPPDATA\CORTEX\imported-catalog-build" -C Debug --output-on-failure
+```
+
+The current native entry point is [include/cortex/imported_catalog_mapper.h](include/cortex/imported_catalog_mapper.h). It exposes the mapper ABI version, descriptor version, imported catalog registration input, mapping result output, stable outcome/error enums, and the subagent bind capacity guard.
+
 ## Current specification set
 
 - [docs/canonical-entity-model.md](docs/canonical-entity-model.md): canonical classes, ownership rules, import boundaries, exports, and provenance handling for `CORTEX #6`
@@ -49,5 +61,10 @@ See [docs/character-ara-doctrine.md](docs/character-ara-doctrine.md) for the cha
 ## Current execution status
 
 - `CORTEX #3`: Done
-- `CORTEX #9`: Active (imported helper/subagent mapping contract)
+- `CORTEX #9`: Done
+- `CORTEX #19`: Active (native imported catalog mapper/runtime enforcement)
 - `CORTEX #2`: In Progress (execution sequencing and PRISM wave entry)
+
+## Functional readiness
+
+CORTEX is roughly 20% complete toward a usable runnable product. The contract set, static progress prototype, and first native C mapper/test slice are in place, but broader character runtime, persistence, live catalog ingestion, complete lifecycle execution, and shell integration are still under implementation.

--- a/include/cortex/imported_catalog_mapper.h
+++ b/include/cortex/imported_catalog_mapper.h
@@ -1,0 +1,122 @@
+#ifndef CORTEX_IMPORTED_CATALOG_MAPPER_H
+#define CORTEX_IMPORTED_CATALOG_MAPPER_H
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CORTEX_IMPORTED_CATALOG_MAPPER_ABI_VERSION_MAJOR 1u
+#define CORTEX_IMPORTED_CATALOG_MAPPER_ABI_VERSION_MINOR 0u
+#define CORTEX_IMPORTED_CATALOG_MAPPER_ABI_VERSION_PATCH 0u
+
+#define CORTEX_DEFAULT_SUBAGENT_LIMIT 12u
+
+typedef enum cortex_import_surface {
+  CORTEX_IMPORT_SURFACE_NONE = 0,
+  CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION = 1,
+  CORTEX_IMPORT_SURFACE_ARRAY_TEMPLATE = 2,
+  CORTEX_IMPORT_SURFACE_CHARACTER_OVERLAY = 3,
+  CORTEX_IMPORT_SURFACE_QUARANTINE = 4
+} cortex_import_surface;
+
+typedef enum cortex_import_outcome {
+  CORTEX_IMPORT_OUTCOME_ACCEPTED = 0,
+  CORTEX_IMPORT_OUTCOME_NARROWED = 1,
+  CORTEX_IMPORT_OUTCOME_QUARANTINED = 2,
+  CORTEX_IMPORT_OUTCOME_REJECTED = 3
+} cortex_import_outcome;
+
+typedef enum cortex_import_lifecycle_state {
+  CORTEX_IMPORT_LIFECYCLE_STAGED = 0,
+  CORTEX_IMPORT_LIFECYCLE_VALIDATED = 1,
+  CORTEX_IMPORT_LIFECYCLE_BOUND = 2,
+  CORTEX_IMPORT_LIFECYCLE_RETIRED = 3
+} cortex_import_lifecycle_state;
+
+typedef enum cortex_import_error {
+  CORTEX_IMPORT_OK = 0,
+  CORTEX_ERR_IMPORT_INVALID_ARGUMENT = 1,
+  CORTEX_ERR_IMPORT_PROVENANCE_INVALID = 2,
+  CORTEX_ERR_IMPORT_CLASS_UNSUPPORTED = 3,
+  CORTEX_ERR_IMPORT_SURFACE_AMBIGUOUS = 4,
+  CORTEX_ERR_IMPORT_REFERENCE_UNRESOLVED = 5,
+  CORTEX_ERR_IMPORT_ARRAY_POLICY_INVALID = 6,
+  CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION = 7,
+  CORTEX_ERR_IMPORT_COMPONENT_INCOMPATIBLE = 8,
+  CORTEX_ERR_IMPORT_PROMOTION_REQUIRED = 9,
+  CORTEX_ERR_EXPORT_HOST_TARGET_UNSUPPORTED = 10,
+  CORTEX_ERR_SUBAGENT_LIMIT_EXCEEDED = 11
+} cortex_import_error;
+
+typedef enum cortex_import_registration_flags {
+  CORTEX_IMPORT_FLAG_NONE = 0u,
+  CORTEX_IMPORT_FLAG_REQUESTS_PERSISTENT_IDENTITY = 1u << 0,
+  CORTEX_IMPORT_FLAG_REPLACES_CHARACTER_OWNER = 1u << 1,
+  CORTEX_IMPORT_FLAG_REPLACES_LIFECYCLE_AUTHORITY = 1u << 2,
+  CORTEX_IMPORT_FLAG_REPLACES_CANONICAL_LABEL = 1u << 3,
+  CORTEX_IMPORT_FLAG_REQUESTS_RUNTIME_ACTIVE_HELPER = 1u << 4
+} cortex_import_registration_flags;
+
+typedef struct cortex_catalog_registration {
+  const char *registration_id;
+  const char *source_repo;
+  const char *source_path;
+  const char *source_commit;
+  const char *source_manifest_ref;
+  const char *runtime_class;
+  const char *canonical_label;
+  const char *array_binding_policy;
+  const char *overlay_kind;
+  const char *prism_compatibility_ref;
+  const char *requested_persistent_class;
+  const char *promotion_policy;
+  const char *compatibility_version;
+  const char *const *host_targets;
+  size_t host_target_count;
+  const char *const *compatible_component_roles;
+  size_t compatible_component_role_count;
+  const char *const *blocked_authority_claims;
+  size_t blocked_authority_claim_count;
+  uint32_t requested_subagent_count;
+  uint32_t component_subagent_limit;
+  uint32_t flags;
+} cortex_catalog_registration;
+
+typedef struct cortex_import_mapping_result {
+  cortex_import_surface surface;
+  cortex_import_outcome outcome;
+  cortex_import_lifecycle_state lifecycle_state;
+  cortex_import_error error;
+  const char *descriptor_id;
+  const char *source_registration_ref;
+  const char *rule_id;
+  const char *message;
+  uint32_t descriptor_version;
+  uint8_t definition_only;
+  uint8_t can_bind_as_subagent;
+} cortex_import_mapping_result;
+
+uint32_t cortex_imported_catalog_mapper_abi_version(void);
+uint32_t cortex_imported_catalog_descriptor_version(void);
+
+cortex_import_error cortex_import_map_registration(
+  const cortex_catalog_registration *registration,
+  cortex_import_mapping_result *result);
+
+cortex_import_error cortex_import_validate_subagent_bind(
+  uint32_t live_or_queued_subagents,
+  uint32_t component_subagent_limit,
+  cortex_import_mapping_result *result);
+
+const char *cortex_import_surface_name(cortex_import_surface surface);
+const char *cortex_import_outcome_name(cortex_import_outcome outcome);
+const char *cortex_import_error_name(cortex_import_error error);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/prototypes/cortex-control-surface.html
+++ b/prototypes/cortex-control-surface.html
@@ -477,20 +477,20 @@
       </div>
         <div class="hero-metrics">
           <div class="metric">
-            <strong>#9 Active</strong>
-            <span>Imported catalog mapping is the live execution head for governed helper, template, and overlay intake.</span>
+            <strong>#19 Active</strong>
+            <span>Native imported catalog mapper enforcement is the live runtime implementation lane.</span>
           </div>
           <div class="metric">
-            <strong>#3 Done</strong>
-            <span>VECTOR, NEXUS, and external execution boundaries are landed and ready for follow-on mapping work.</span>
+            <strong>#9 Done</strong>
+            <span>Imported helper, template, overlay, and lifecycle ownership mapping rules are landed.</span>
           </div>
           <div class="metric">
-            <strong>8 / 8 Contracts Done</strong>
-            <span>The first-wave contract set is complete; #9 now turns those contracts into imported-catalog ownership rules.</span>
+            <strong>9 / 9 Contract Lanes Done</strong>
+            <span>The contract foundation is complete; #19 starts native runtime enforcement.</span>
           </div>
           <div class="metric">
-            <strong>30% Product Ready</strong>
-            <span>The project is still early overall because runnable implementation and downstream integration remain incomplete.</span>
+            <strong>20% Product Ready</strong>
+            <span>The first native mapper slice is underway; broader runtime, persistence, ingestion, and shell integration remain incomplete.</span>
           </div>
         </div>
         <div class="progress-strip">
@@ -501,7 +501,7 @@
           <div class="progress-track" aria-label="Execution wave progress">
             <span class="progress-fill" style="width: 100%;"></span>
           </div>
-          <p>Done: #6, #5, #10, #4, #11, #7, #8, #3. Active: #9 imported catalog mapping.</p>
+          <p>Done: #6, #5, #10, #4, #11, #7, #8, #3, #9. Active: #19 native mapper enforcement.</p>
         </div>
     </section>
 
@@ -545,11 +545,17 @@
             <div class="status-tag done">Done</div>
             <p>VECTOR, NEXUS, and external execution targets are bounded so imported definitions can enter governed CORTEX surfaces.</p>
           </div>
-          <div class="wave-card current">
+          <div class="wave-card">
             <div class="issue">Issue #9</div>
             <strong>Catalog mapping</strong>
+            <div class="status-tag done">Done</div>
+            <p>Imported external subagent definitions now have governed helper, template, overlay, and lifecycle ownership mapping rules.</p>
+          </div>
+          <div class="wave-card current">
+            <div class="issue">Issue #19</div>
+            <strong>Native mapper enforcement</strong>
             <div class="status-tag active">Active</div>
-            <p>Imported external subagent definitions now map into governed helper, template, overlay, and lifecycle ownership surfaces.</p>
+            <p>Native descriptors, classifier outcomes, stable errors, and validation coverage turn the mapping contract into executable behavior.</p>
           </div>
         </div>
       </article>
@@ -592,11 +598,11 @@
           </div>
           <div class="io-card">
             <strong>Project visibility</strong>
-            <p>The execution wave stays read-only, shows done or active state, and distinguishes first-wave planning progress from imported-catalog mapping work.</p>
+            <p>The execution wave stays read-only, shows done or active state, and distinguishes contract completion from native runtime enforcement.</p>
           </div>
           <div class="io-card">
             <strong>Project pulse</strong>
-            <p>Issue #3 is done, the first-wave contract set is complete, #9 is active, and the product is still early overall despite stronger architectural coverage.</p>
+            <p>Issue #9 is done, #19 is active, and the product remains early until the native core, tests, persistence, and shell integration land.</p>
           </div>
         </div>
       </article>

--- a/src/imported_catalog_mapper.c
+++ b/src/imported_catalog_mapper.c
@@ -1,0 +1,421 @@
+#include "cortex/imported_catalog_mapper.h"
+
+#include <string.h>
+
+#define CORTEX_DESCRIPTOR_VERSION 1u
+
+static int is_empty(const char *value) {
+  return value == 0 || value[0] == '\0';
+}
+
+static int equals(const char *left, const char *right) {
+  return left != 0 && right != 0 && strcmp(left, right) == 0;
+}
+
+static int is_supported_host_target(const char *target) {
+  return equals(target, "codex") ||
+         equals(target, "openclaw") ||
+         equals(target, "symbiosis-native") ||
+         equals(target, "acp-bridge") ||
+         equals(target, "VECTOR") ||
+         equals(target, "NEXUS") ||
+         equals(target, "vector") ||
+         equals(target, "nexus");
+}
+
+static int is_helper_class(const char *runtime_class) {
+  return equals(runtime_class, "helper") ||
+         equals(runtime_class, "imported-helper") ||
+         equals(runtime_class, "subagent-helper") ||
+         equals(runtime_class, "ImportedHelperSubagentDefinition");
+}
+
+static int is_template_class(const char *runtime_class) {
+  return equals(runtime_class, "array-template") ||
+         equals(runtime_class, "imported-array-template") ||
+         equals(runtime_class, "ImportedArrayTemplate");
+}
+
+static int is_overlay_class(const char *runtime_class) {
+  return equals(runtime_class, "character-overlay") ||
+         equals(runtime_class, "imported-character-overlay") ||
+         equals(runtime_class, "overlay") ||
+         equals(runtime_class, "ImportedCharacterOverlay");
+}
+
+static int is_persistent_identity_class(const char *class_name) {
+  return equals(class_name, "Symbiote") ||
+         equals(class_name, "Curator") ||
+         equals(class_name, "Character") ||
+         equals(class_name, "symbiote") ||
+         equals(class_name, "curator") ||
+         equals(class_name, "character");
+}
+
+static int is_valid_array_policy(const char *policy) {
+  return equals(policy, "two_component") ||
+         equals(policy, "three_component") ||
+         equals(policy, "larger_justified");
+}
+
+static int is_personality_or_stylization_overlay(const char *overlay_kind) {
+  return equals(overlay_kind, "personality") ||
+         equals(overlay_kind, "stylization") ||
+         equals(overlay_kind, "prism") ||
+         equals(overlay_kind, "PRISM");
+}
+
+static void clear_result(cortex_import_mapping_result *result) {
+  if (result == 0) {
+    return;
+  }
+
+  result->surface = CORTEX_IMPORT_SURFACE_NONE;
+  result->outcome = CORTEX_IMPORT_OUTCOME_REJECTED;
+  result->lifecycle_state = CORTEX_IMPORT_LIFECYCLE_STAGED;
+  result->error = CORTEX_ERR_IMPORT_INVALID_ARGUMENT;
+  result->descriptor_id = 0;
+  result->source_registration_ref = 0;
+  result->rule_id = "invalid_argument";
+  result->message = "invalid mapper argument";
+  result->descriptor_version = CORTEX_DESCRIPTOR_VERSION;
+  result->definition_only = 0u;
+  result->can_bind_as_subagent = 0u;
+}
+
+static cortex_import_error finish(
+  cortex_import_mapping_result *result,
+  cortex_import_surface surface,
+  cortex_import_outcome outcome,
+  cortex_import_error error,
+  const cortex_catalog_registration *registration,
+  const char *rule_id,
+  const char *message) {
+  if (result != 0) {
+    result->surface = surface;
+    result->outcome = outcome;
+    result->lifecycle_state = CORTEX_IMPORT_LIFECYCLE_STAGED;
+    result->error = error;
+    result->descriptor_id = registration != 0 ? registration->registration_id : 0;
+    result->source_registration_ref = registration != 0 ? registration->registration_id : 0;
+    result->rule_id = rule_id;
+    result->message = message;
+    result->descriptor_version = CORTEX_DESCRIPTOR_VERSION;
+    result->definition_only = surface == CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION ? 1u : 0u;
+    result->can_bind_as_subagent =
+      surface == CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION &&
+      outcome == CORTEX_IMPORT_OUTCOME_ACCEPTED ? 1u : 0u;
+  }
+
+  return error;
+}
+
+static cortex_import_error reject(
+  cortex_import_mapping_result *result,
+  cortex_import_error error,
+  const cortex_catalog_registration *registration,
+  const char *rule_id,
+  const char *message) {
+  return finish(result, CORTEX_IMPORT_SURFACE_NONE, CORTEX_IMPORT_OUTCOME_REJECTED,
+                error, registration, rule_id, message);
+}
+
+static int has_valid_provenance(const cortex_catalog_registration *registration) {
+  return !is_empty(registration->registration_id) &&
+         !is_empty(registration->source_repo) &&
+         !is_empty(registration->source_path) &&
+         !is_empty(registration->source_commit);
+}
+
+static cortex_import_error validate_host_targets(
+  const cortex_catalog_registration *registration,
+  cortex_import_mapping_result *result,
+  int *narrowed) {
+  size_t index = 0u;
+  size_t supported_count = 0u;
+
+  if (narrowed != 0) {
+    *narrowed = 0;
+  }
+
+  if (registration->host_target_count == 0u || registration->host_targets == 0) {
+    return reject(result, CORTEX_ERR_EXPORT_HOST_TARGET_UNSUPPORTED, registration,
+                  "host_target_required",
+                  "at least one supported host target is required");
+  }
+
+  for (index = 0u; index < registration->host_target_count; ++index) {
+    if (is_supported_host_target(registration->host_targets[index])) {
+      ++supported_count;
+    }
+  }
+
+  if (supported_count == 0u) {
+    return reject(result, CORTEX_ERR_EXPORT_HOST_TARGET_UNSUPPORTED, registration,
+                  "host_target_unsupported",
+                  "host target is unsupported by the CORTEX external boundary");
+  }
+
+  if (supported_count < registration->host_target_count && narrowed != 0) {
+    *narrowed = 1;
+  }
+
+  return CORTEX_IMPORT_OK;
+}
+
+static int requests_authority_replacement(const cortex_catalog_registration *registration) {
+  return (registration->flags & CORTEX_IMPORT_FLAG_REPLACES_CHARACTER_OWNER) != 0u ||
+         (registration->flags & CORTEX_IMPORT_FLAG_REPLACES_LIFECYCLE_AUTHORITY) != 0u ||
+         (registration->flags & CORTEX_IMPORT_FLAG_REPLACES_CANONICAL_LABEL) != 0u;
+}
+
+static cortex_import_error validate_no_promotion(
+  const cortex_catalog_registration *registration,
+  cortex_import_mapping_result *result) {
+  if ((registration->flags & CORTEX_IMPORT_FLAG_REQUESTS_PERSISTENT_IDENTITY) != 0u ||
+      is_persistent_identity_class(registration->runtime_class) ||
+      is_persistent_identity_class(registration->requested_persistent_class)) {
+    return reject(result, CORTEX_ERR_IMPORT_PROMOTION_REQUIRED, registration,
+                  "persistent_identity_promotion_blocked",
+                  "imported descriptors may not become persistent identities by default");
+  }
+
+  if ((registration->flags & CORTEX_IMPORT_FLAG_REQUESTS_RUNTIME_ACTIVE_HELPER) != 0u) {
+    return reject(result, CORTEX_ERR_IMPORT_PROMOTION_REQUIRED, registration,
+                  "runtime_active_helper_requires_binding",
+                  "imported helpers stay definition-only until bound as SubagentInstance");
+  }
+
+  return CORTEX_IMPORT_OK;
+}
+
+static cortex_import_error validate_subagent_limit_from_registration(
+  const cortex_catalog_registration *registration,
+  cortex_import_mapping_result *result) {
+  uint32_t limit = registration->component_subagent_limit;
+  if (limit == 0u) {
+    limit = CORTEX_DEFAULT_SUBAGENT_LIMIT;
+  }
+
+  if (registration->requested_subagent_count > limit) {
+    return reject(result, CORTEX_ERR_SUBAGENT_LIMIT_EXCEEDED, registration,
+                  "component_subagent_limit_exceeded",
+                  "requested helper binding would exceed component subagent limit");
+  }
+
+  return CORTEX_IMPORT_OK;
+}
+
+uint32_t cortex_imported_catalog_mapper_abi_version(void) {
+  return (CORTEX_IMPORTED_CATALOG_MAPPER_ABI_VERSION_MAJOR << 16) |
+         (CORTEX_IMPORTED_CATALOG_MAPPER_ABI_VERSION_MINOR << 8) |
+         CORTEX_IMPORTED_CATALOG_MAPPER_ABI_VERSION_PATCH;
+}
+
+uint32_t cortex_imported_catalog_descriptor_version(void) {
+  return CORTEX_DESCRIPTOR_VERSION;
+}
+
+cortex_import_error cortex_import_map_registration(
+  const cortex_catalog_registration *registration,
+  cortex_import_mapping_result *result) {
+  cortex_import_error error = CORTEX_IMPORT_OK;
+  int narrowed = 0;
+
+  clear_result(result);
+
+  if (registration == 0 || result == 0) {
+    return CORTEX_ERR_IMPORT_INVALID_ARGUMENT;
+  }
+
+  if (!has_valid_provenance(registration)) {
+    return reject(result, CORTEX_ERR_IMPORT_PROVENANCE_INVALID, registration,
+                  "provenance_required",
+                  "registration id, source repo, source path, and source commit are required");
+  }
+
+  error = validate_host_targets(registration, result, &narrowed);
+  if (error != CORTEX_IMPORT_OK) {
+    return error;
+  }
+
+  error = validate_no_promotion(registration, result);
+  if (error != CORTEX_IMPORT_OK) {
+    return error;
+  }
+
+  if (requests_authority_replacement(registration)) {
+    return reject(result, CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION, registration,
+                  "authority_replacement_blocked",
+                  "imported descriptors may not replace owner, lifecycle, or label authority");
+  }
+
+  if (is_helper_class(registration->runtime_class)) {
+    if (registration->compatible_component_role_count == 0u ||
+        registration->compatible_component_roles == 0) {
+      return reject(result, CORTEX_ERR_IMPORT_COMPONENT_INCOMPATIBLE, registration,
+                    "helper_component_role_required",
+                    "helper definitions require at least one compatible component role");
+    }
+
+    error = validate_subagent_limit_from_registration(registration, result);
+    if (error != CORTEX_IMPORT_OK) {
+      return error;
+    }
+
+    return finish(result, CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION,
+                  narrowed ? CORTEX_IMPORT_OUTCOME_NARROWED : CORTEX_IMPORT_OUTCOME_ACCEPTED,
+                  CORTEX_IMPORT_OK, registration,
+                  narrowed ? "host_targets_narrowed" : "helper_definition_accepted",
+                  narrowed ? "imported helper accepted after unsupported host targets were narrowed" :
+                             "imported helper accepted as definition-only descriptor");
+  }
+
+  if (is_template_class(registration->runtime_class)) {
+    if (!is_valid_array_policy(registration->array_binding_policy)) {
+      return reject(result, CORTEX_ERR_IMPORT_ARRAY_POLICY_INVALID, registration,
+                    "array_policy_invalid",
+                    "array templates require a valid array binding policy");
+    }
+
+    return finish(result, CORTEX_IMPORT_SURFACE_ARRAY_TEMPLATE,
+                  narrowed ? CORTEX_IMPORT_OUTCOME_NARROWED : CORTEX_IMPORT_OUTCOME_ACCEPTED,
+                  CORTEX_IMPORT_OK, registration,
+                  narrowed ? "host_targets_narrowed" : "array_template_accepted",
+                  narrowed ? "imported array template accepted after unsupported host targets were narrowed" :
+                             "imported array template accepted as construction seed");
+  }
+
+  if (is_overlay_class(registration->runtime_class)) {
+    if (registration->blocked_authority_claim_count == 0u ||
+        registration->blocked_authority_claims == 0) {
+      return reject(result, CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION, registration,
+                    "overlay_blocked_claims_required",
+                    "overlays must declare blocked authority claims");
+    }
+
+    if (is_personality_or_stylization_overlay(registration->overlay_kind) &&
+        is_empty(registration->prism_compatibility_ref)) {
+      return reject(result, CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION, registration,
+                    "overlay_prism_compatibility_required",
+                    "personality or stylization overlays require PRISM compatibility");
+    }
+
+    return finish(result, CORTEX_IMPORT_SURFACE_CHARACTER_OVERLAY,
+                  narrowed ? CORTEX_IMPORT_OUTCOME_NARROWED : CORTEX_IMPORT_OUTCOME_ACCEPTED,
+                  CORTEX_IMPORT_OK, registration,
+                  narrowed ? "host_targets_narrowed" : "character_overlay_accepted",
+                  narrowed ? "imported character overlay accepted after unsupported host targets were narrowed" :
+                             "imported character overlay accepted as bounded attachment");
+  }
+
+  return finish(result, CORTEX_IMPORT_SURFACE_QUARANTINE,
+                CORTEX_IMPORT_OUTCOME_QUARANTINED,
+                CORTEX_ERR_IMPORT_CLASS_UNSUPPORTED,
+                registration,
+                "runtime_class_quarantined",
+                "runtime class has valid provenance but is not supported yet");
+}
+
+cortex_import_error cortex_import_validate_subagent_bind(
+  uint32_t live_or_queued_subagents,
+  uint32_t component_subagent_limit,
+  cortex_import_mapping_result *result) {
+  uint32_t limit = component_subagent_limit;
+  clear_result(result);
+
+  if (result == 0) {
+    return CORTEX_ERR_IMPORT_INVALID_ARGUMENT;
+  }
+
+  if (limit == 0u) {
+    limit = CORTEX_DEFAULT_SUBAGENT_LIMIT;
+  }
+
+  result->surface = CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION;
+  result->source_registration_ref = 0;
+  result->descriptor_id = 0;
+  result->descriptor_version = CORTEX_DESCRIPTOR_VERSION;
+
+  if (live_or_queued_subagents >= limit) {
+    result->outcome = CORTEX_IMPORT_OUTCOME_REJECTED;
+    result->lifecycle_state = CORTEX_IMPORT_LIFECYCLE_STAGED;
+    result->error = CORTEX_ERR_SUBAGENT_LIMIT_EXCEEDED;
+    result->rule_id = "component_subagent_limit_exceeded";
+    result->message = "component already has the maximum live or queued subagents";
+    result->definition_only = 1u;
+    result->can_bind_as_subagent = 0u;
+    return CORTEX_ERR_SUBAGENT_LIMIT_EXCEEDED;
+  }
+
+  result->outcome = CORTEX_IMPORT_OUTCOME_ACCEPTED;
+  result->lifecycle_state = CORTEX_IMPORT_LIFECYCLE_STAGED;
+  result->error = CORTEX_IMPORT_OK;
+  result->rule_id = "subagent_bind_allowed";
+  result->message = "component has capacity for one governed SubagentInstance";
+  result->definition_only = 1u;
+  result->can_bind_as_subagent = 1u;
+  return CORTEX_IMPORT_OK;
+}
+
+const char *cortex_import_surface_name(cortex_import_surface surface) {
+  switch (surface) {
+    case CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION:
+      return "ImportedHelperSubagentDefinition";
+    case CORTEX_IMPORT_SURFACE_ARRAY_TEMPLATE:
+      return "ImportedArrayTemplate";
+    case CORTEX_IMPORT_SURFACE_CHARACTER_OVERLAY:
+      return "ImportedCharacterOverlay";
+    case CORTEX_IMPORT_SURFACE_QUARANTINE:
+      return "Quarantine";
+    case CORTEX_IMPORT_SURFACE_NONE:
+    default:
+      return "None";
+  }
+}
+
+const char *cortex_import_outcome_name(cortex_import_outcome outcome) {
+  switch (outcome) {
+    case CORTEX_IMPORT_OUTCOME_ACCEPTED:
+      return "accepted";
+    case CORTEX_IMPORT_OUTCOME_NARROWED:
+      return "narrowed";
+    case CORTEX_IMPORT_OUTCOME_QUARANTINED:
+      return "quarantined";
+    case CORTEX_IMPORT_OUTCOME_REJECTED:
+      return "rejected";
+    default:
+      return "unknown";
+  }
+}
+
+const char *cortex_import_error_name(cortex_import_error error) {
+  switch (error) {
+    case CORTEX_IMPORT_OK:
+      return "CORTEX_IMPORT_OK";
+    case CORTEX_ERR_IMPORT_INVALID_ARGUMENT:
+      return "CORTEX_ERR_IMPORT_INVALID_ARGUMENT";
+    case CORTEX_ERR_IMPORT_PROVENANCE_INVALID:
+      return "CORTEX_ERR_IMPORT_PROVENANCE_INVALID";
+    case CORTEX_ERR_IMPORT_CLASS_UNSUPPORTED:
+      return "CORTEX_ERR_IMPORT_CLASS_UNSUPPORTED";
+    case CORTEX_ERR_IMPORT_SURFACE_AMBIGUOUS:
+      return "CORTEX_ERR_IMPORT_SURFACE_AMBIGUOUS";
+    case CORTEX_ERR_IMPORT_REFERENCE_UNRESOLVED:
+      return "CORTEX_ERR_IMPORT_REFERENCE_UNRESOLVED";
+    case CORTEX_ERR_IMPORT_ARRAY_POLICY_INVALID:
+      return "CORTEX_ERR_IMPORT_ARRAY_POLICY_INVALID";
+    case CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION:
+      return "CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION";
+    case CORTEX_ERR_IMPORT_COMPONENT_INCOMPATIBLE:
+      return "CORTEX_ERR_IMPORT_COMPONENT_INCOMPATIBLE";
+    case CORTEX_ERR_IMPORT_PROMOTION_REQUIRED:
+      return "CORTEX_ERR_IMPORT_PROMOTION_REQUIRED";
+    case CORTEX_ERR_EXPORT_HOST_TARGET_UNSUPPORTED:
+      return "CORTEX_ERR_EXPORT_HOST_TARGET_UNSUPPORTED";
+    case CORTEX_ERR_SUBAGENT_LIMIT_EXCEEDED:
+      return "CORTEX_ERR_SUBAGENT_LIMIT_EXCEEDED";
+    default:
+      return "CORTEX_ERR_UNKNOWN";
+  }
+}

--- a/tests/test_imported_catalog_mapper.c
+++ b/tests/test_imported_catalog_mapper.c
@@ -1,0 +1,263 @@
+#include "cortex/imported_catalog_mapper.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define CHECK(condition) \
+  do { \
+    if (!(condition)) { \
+      fprintf(stderr, "CHECK failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+      ++failures; \
+    } \
+  } while (0)
+
+static cortex_catalog_registration base_registration(void) {
+  static const char *host_targets[] = {"codex", "symbiosis-native"};
+  cortex_catalog_registration registration;
+
+  memset(&registration, 0, sizeof(registration));
+  registration.registration_id = "catalog-entry-1";
+  registration.source_repo = "JKhyro/SYMBIOSIS";
+  registration.source_path = ".codex/agents/helper.toml";
+  registration.source_commit = "5f855c11f9117541da31e7274b738cc396d4d3c7";
+  registration.source_manifest_ref = "khyron-subagent";
+  registration.canonical_label = "Imported helper";
+  registration.compatibility_version = "1";
+  registration.host_targets = host_targets;
+  registration.host_target_count = 2u;
+  return registration;
+}
+
+static void accepts_helper_definition_only(void) {
+  static const char *roles[] = {"active", "memory"};
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "imported-helper";
+  registration.compatible_component_roles = roles;
+  registration.compatible_component_role_count = 2u;
+  registration.requested_subagent_count = 1u;
+
+  CHECK(cortex_import_map_registration(&registration, &result) == CORTEX_IMPORT_OK);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_ACCEPTED);
+  CHECK(result.surface == CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION);
+  CHECK(result.lifecycle_state == CORTEX_IMPORT_LIFECYCLE_STAGED);
+  CHECK(result.definition_only == 1u);
+  CHECK(result.can_bind_as_subagent == 1u);
+  CHECK(strcmp(cortex_import_surface_name(result.surface), "ImportedHelperSubagentDefinition") == 0);
+}
+
+static void accepts_array_template(void) {
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "array-template";
+  registration.array_binding_policy = "three_component";
+
+  CHECK(cortex_import_map_registration(&registration, &result) == CORTEX_IMPORT_OK);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_ACCEPTED);
+  CHECK(result.surface == CORTEX_IMPORT_SURFACE_ARRAY_TEMPLATE);
+  CHECK(result.definition_only == 0u);
+  CHECK(result.error == CORTEX_IMPORT_OK);
+}
+
+static void accepts_character_overlay(void) {
+  static const char *blocked_claims[] = {"owner", "lifecycle", "canonical_label"};
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "character-overlay";
+  registration.overlay_kind = "governance";
+  registration.blocked_authority_claims = blocked_claims;
+  registration.blocked_authority_claim_count = 3u;
+
+  CHECK(cortex_import_map_registration(&registration, &result) == CORTEX_IMPORT_OK);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_ACCEPTED);
+  CHECK(result.surface == CORTEX_IMPORT_SURFACE_CHARACTER_OVERLAY);
+  CHECK(result.error == CORTEX_IMPORT_OK);
+}
+
+static void narrows_mixed_host_targets(void) {
+  static const char *host_targets[] = {"codex", "root-shell"};
+  static const char *roles[] = {"active"};
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "imported-helper";
+  registration.host_targets = host_targets;
+  registration.host_target_count = 2u;
+  registration.compatible_component_roles = roles;
+  registration.compatible_component_role_count = 1u;
+
+  CHECK(cortex_import_map_registration(&registration, &result) == CORTEX_IMPORT_OK);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_NARROWED);
+  CHECK(result.surface == CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION);
+  CHECK(result.error == CORTEX_IMPORT_OK);
+  CHECK(strcmp(result.rule_id, "host_targets_narrowed") == 0);
+  CHECK(strcmp(cortex_import_outcome_name(result.outcome), "narrowed") == 0);
+}
+
+static void narrows_array_template_mixed_host_targets(void) {
+  static const char *host_targets[] = {"nexus", "root-shell"};
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "array-template";
+  registration.host_targets = host_targets;
+  registration.host_target_count = 2u;
+  registration.array_binding_policy = "two_component";
+
+  CHECK(cortex_import_map_registration(&registration, &result) == CORTEX_IMPORT_OK);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_NARROWED);
+  CHECK(result.surface == CORTEX_IMPORT_SURFACE_ARRAY_TEMPLATE);
+  CHECK(result.error == CORTEX_IMPORT_OK);
+  CHECK(strcmp(result.rule_id, "host_targets_narrowed") == 0);
+}
+
+static void narrows_overlay_mixed_host_targets(void) {
+  static const char *host_targets[] = {"VECTOR", "root-shell"};
+  static const char *blocked_claims[] = {"owner", "lifecycle", "canonical_label"};
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "character-overlay";
+  registration.host_targets = host_targets;
+  registration.host_target_count = 2u;
+  registration.overlay_kind = "governance";
+  registration.blocked_authority_claims = blocked_claims;
+  registration.blocked_authority_claim_count = 3u;
+
+  CHECK(cortex_import_map_registration(&registration, &result) == CORTEX_IMPORT_OK);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_NARROWED);
+  CHECK(result.surface == CORTEX_IMPORT_SURFACE_CHARACTER_OVERLAY);
+  CHECK(result.error == CORTEX_IMPORT_OK);
+  CHECK(strcmp(result.rule_id, "host_targets_narrowed") == 0);
+}
+
+static void quarantines_unknown_runtime_class(void) {
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "future-runtime-class";
+
+  CHECK(cortex_import_map_registration(&registration, &result) == CORTEX_ERR_IMPORT_CLASS_UNSUPPORTED);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_QUARANTINED);
+  CHECK(result.surface == CORTEX_IMPORT_SURFACE_QUARANTINE);
+  CHECK(result.error == CORTEX_ERR_IMPORT_CLASS_UNSUPPORTED);
+}
+
+static void rejects_persistent_identity_promotion(void) {
+  static const char *roles[] = {"active"};
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "imported-helper";
+  registration.compatible_component_roles = roles;
+  registration.compatible_component_role_count = 1u;
+  registration.requested_persistent_class = "Symbiote";
+
+  CHECK(cortex_import_map_registration(&registration, &result) == CORTEX_ERR_IMPORT_PROMOTION_REQUIRED);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_REJECTED);
+  CHECK(result.error == CORTEX_ERR_IMPORT_PROMOTION_REQUIRED);
+}
+
+static void rejects_owner_or_lifecycle_replacement(void) {
+  static const char *blocked_claims[] = {"owner", "lifecycle"};
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "character-overlay";
+  registration.overlay_kind = "governance";
+  registration.blocked_authority_claims = blocked_claims;
+  registration.blocked_authority_claim_count = 2u;
+  registration.flags = CORTEX_IMPORT_FLAG_REPLACES_CHARACTER_OWNER |
+                       CORTEX_IMPORT_FLAG_REPLACES_LIFECYCLE_AUTHORITY;
+
+  CHECK(cortex_import_map_registration(&registration, &result) ==
+        CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_REJECTED);
+  CHECK(result.error == CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION);
+}
+
+static void rejects_unsupported_host_target(void) {
+  static const char *host_targets[] = {"root-shell"};
+  static const char *roles[] = {"active"};
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "imported-helper";
+  registration.host_targets = host_targets;
+  registration.host_target_count = 1u;
+  registration.compatible_component_roles = roles;
+  registration.compatible_component_role_count = 1u;
+
+  CHECK(cortex_import_map_registration(&registration, &result) ==
+        CORTEX_ERR_EXPORT_HOST_TARGET_UNSUPPORTED);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_REJECTED);
+  CHECK(result.error == CORTEX_ERR_EXPORT_HOST_TARGET_UNSUPPORTED);
+}
+
+static void rejects_invalid_overlay_prism_compatibility(void) {
+  static const char *blocked_claims[] = {"owner", "lifecycle", "canonical_label"};
+  cortex_import_mapping_result result;
+  cortex_catalog_registration registration = base_registration();
+
+  registration.runtime_class = "character-overlay";
+  registration.overlay_kind = "stylization";
+  registration.blocked_authority_claims = blocked_claims;
+  registration.blocked_authority_claim_count = 3u;
+
+  CHECK(cortex_import_map_registration(&registration, &result) ==
+        CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_REJECTED);
+  CHECK(result.error == CORTEX_ERR_IMPORT_OVERLAY_AUTHORITY_VIOLATION);
+}
+
+static void rejects_subagent_limit_exceeded(void) {
+  cortex_import_mapping_result result;
+
+  CHECK(cortex_import_validate_subagent_bind(CORTEX_DEFAULT_SUBAGENT_LIMIT,
+                                             CORTEX_DEFAULT_SUBAGENT_LIMIT,
+                                             &result) ==
+        CORTEX_ERR_SUBAGENT_LIMIT_EXCEEDED);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_REJECTED);
+  CHECK(result.error == CORTEX_ERR_SUBAGENT_LIMIT_EXCEEDED);
+  CHECK(result.can_bind_as_subagent == 0u);
+}
+
+static void accepts_subagent_bind_with_capacity(void) {
+  cortex_import_mapping_result result;
+
+  CHECK(cortex_import_validate_subagent_bind(3u, CORTEX_DEFAULT_SUBAGENT_LIMIT, &result) ==
+        CORTEX_IMPORT_OK);
+  CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_ACCEPTED);
+  CHECK(result.can_bind_as_subagent == 1u);
+}
+
+int main(void) {
+  CHECK(cortex_imported_catalog_mapper_abi_version() == 0x00010000u);
+  CHECK(cortex_imported_catalog_descriptor_version() == 1u);
+  accepts_helper_definition_only();
+  accepts_array_template();
+  accepts_character_overlay();
+  narrows_mixed_host_targets();
+  narrows_array_template_mixed_host_targets();
+  narrows_overlay_mixed_host_targets();
+  quarantines_unknown_runtime_class();
+  rejects_persistent_identity_promotion();
+  rejects_owner_or_lifecycle_replacement();
+  rejects_unsupported_host_target();
+  rejects_invalid_overlay_prism_compatibility();
+  rejects_subagent_limit_exceeded();
+  accepts_subagent_bind_with_capacity();
+
+  if (failures != 0) {
+    fprintf(stderr, "%d imported catalog mapper test failure(s)\n", failures);
+    return 1;
+  }
+
+  puts("imported catalog mapper tests passed");
+  return 0;
+}


### PR DESCRIPTION
## Summary
- adds the first native C runtime slice for CORTEX#19 with a public imported catalog mapper ABI
- adds descriptor/outcome/lifecycle/error enums and mapping result structs for helper definitions, array templates, character overlays, quarantine, rejection, and narrowed outcomes
- implements mapper enforcement for provenance, host targets, persistent identity promotion, ownership/lifecycle/label authority replacement, PRISM-bound overlay compatibility, and subagent capacity
- updates README/prototype progress surfaces to show #19 Active and a conservative 20% usable-product readiness estimate

## Verification
- cmake -S . -B "$env:LOCALAPPDATA\CORTEX\imported-catalog-build"
- cmake --build "$env:LOCALAPPDATA\CORTEX\imported-catalog-build" --config Debug
- ctest --test-dir "$env:LOCALAPPDATA\CORTEX\imported-catalog-build" -C Debug --output-on-failure
- git diff --check -- CMakeLists.txt include src tests README.md prototypes/cortex-control-surface.html

Closes #19
Updates #2
