### PR TITLE
Implement native character lifecycle core

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -12,14 +12,26 @@ set(CMAKE_C_EXTENSIONS OFF)
 add_library(cortex_imported_catalog_mapper STATIC
   src/imported_catalog_mapper.c)
 
+add_library(cortex_character_runtime STATIC
+  src/character_runtime.c)
+
 target_include_directories(cortex_imported_catalog_mapper
   PUBLIC
     ${CMAKE_CURRENT_SOURCE_DIR}/include)
 
+target_include_directories(cortex_character_runtime
+  PUBLIC
+    ${CMAKE_CURRENT_SOURCE_DIR}/include)
+
+target_link_libraries(cortex_character_runtime
+  PUBLIC cortex_imported_catalog_mapper)
+
 if(MSVC)
   target_compile_options(cortex_imported_catalog_mapper PRIVATE /W4 /permissive-)
+  target_compile_options(cortex_character_runtime PRIVATE /W4 /permissive-)
 else()
   target_compile_options(cortex_imported_catalog_mapper PRIVATE -Wall -Wextra -Wpedantic)
+  target_compile_options(cortex_character_runtime PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
 enable_testing()
@@ -27,14 +39,25 @@ enable_testing()
 add_executable(cortex_imported_catalog_mapper_tests
   tests/test_imported_catalog_mapper.c)
 
+add_executable(cortex_character_runtime_tests
+  tests/test_character_runtime.c)
+
 target_link_libraries(cortex_imported_catalog_mapper_tests
   PRIVATE cortex_imported_catalog_mapper)
 
+target_link_libraries(cortex_character_runtime_tests
+  PRIVATE cortex_character_runtime)
+
 if(MSVC)
   target_compile_options(cortex_imported_catalog_mapper_tests PRIVATE /W4 /permissive-)
+  target_compile_options(cortex_character_runtime_tests PRIVATE /W4 /permissive-)
 else()
   target_compile_options(cortex_imported_catalog_mapper_tests PRIVATE -Wall -Wextra -Wpedantic)
+  target_compile_options(cortex_character_runtime_tests PRIVATE -Wall -Wextra -Wpedantic)
 endif()
 
 add_test(NAME cortex_imported_catalog_mapper_tests
   COMMAND cortex_imported_catalog_mapper_tests)
+
+add_test(NAME cortex_character_runtime_tests
+  COMMAND cortex_character_runtime_tests)

--- a/include/cortex/character_runtime.h
+++ b/include/cortex/character_runtime.h
@@ -1,0 +1,183 @@
+#ifndef CORTEX_CHARACTER_RUNTIME_H
+#define CORTEX_CHARACTER_RUNTIME_H
+
+#include "cortex/imported_catalog_mapper.h"
+
+#include <stddef.h>
+#include <stdint.h>
+
+#ifdef __cplusplus
+extern "C" {
+#endif
+
+#define CORTEX_CHARACTER_RUNTIME_ABI_VERSION_MAJOR 1u
+#define CORTEX_CHARACTER_RUNTIME_ABI_VERSION_MINOR 0u
+#define CORTEX_CHARACTER_RUNTIME_ABI_VERSION_PATCH 0u
+
+typedef enum cortex_ara_shape {
+  CORTEX_ARA_SHAPE_TWO_COMPONENT = 2,
+  CORTEX_ARA_SHAPE_THREE_COMPONENT = 3,
+  CORTEX_ARA_SHAPE_LARGER_JUSTIFIED = 4
+} cortex_ara_shape;
+
+typedef enum cortex_component_role {
+  CORTEX_COMPONENT_ROLE_INVALID = 0,
+  CORTEX_COMPONENT_ROLE_ACTIVE = 1,
+  CORTEX_COMPONENT_ROLE_MEMORY = 2,
+  CORTEX_COMPONENT_ROLE_REASONING = 3
+} cortex_component_role;
+
+typedef enum cortex_character_state {
+  CORTEX_CHARACTER_DRAFT = 0,
+  CORTEX_CHARACTER_ASSEMBLING = 1,
+  CORTEX_CHARACTER_VALIDATED = 2,
+  CORTEX_CHARACTER_READY = 3,
+  CORTEX_CHARACTER_ACTIVE = 4,
+  CORTEX_CHARACTER_SUSPENDED = 5,
+  CORTEX_CHARACTER_DEGRADED = 6,
+  CORTEX_CHARACTER_ARCHIVED = 7
+} cortex_character_state;
+
+typedef enum cortex_component_state {
+  CORTEX_COMPONENT_STAGED = 0,
+  CORTEX_COMPONENT_BOUND = 1,
+  CORTEX_COMPONENT_VALIDATED = 2,
+  CORTEX_COMPONENT_READY = 3,
+  CORTEX_COMPONENT_ACTIVE = 4,
+  CORTEX_COMPONENT_SUSPENDED = 5,
+  CORTEX_COMPONENT_DEGRADED = 6,
+  CORTEX_COMPONENT_DETACHED = 7,
+  CORTEX_COMPONENT_ARCHIVED = 8
+} cortex_component_state;
+
+typedef enum cortex_subagent_state {
+  CORTEX_SUBAGENT_DEFINED = 0,
+  CORTEX_SUBAGENT_QUEUED = 1,
+  CORTEX_SUBAGENT_ACTIVE = 2,
+  CORTEX_SUBAGENT_SUSPENDED = 3,
+  CORTEX_SUBAGENT_DESPAWNED = 4,
+  CORTEX_SUBAGENT_ARCHIVED = 5
+} cortex_subagent_state;
+
+typedef enum cortex_control_verb {
+  CORTEX_VERB_VALIDATE_CHARACTER = 0,
+  CORTEX_VERB_MARK_READY = 1,
+  CORTEX_VERB_ACTIVATE_CHARACTER = 2,
+  CORTEX_VERB_SUSPEND_CHARACTER = 3,
+  CORTEX_VERB_RESUME_CHARACTER = 4,
+  CORTEX_VERB_DEGRADE_CHARACTER = 5,
+  CORTEX_VERB_RESTORE_CHARACTER = 6,
+  CORTEX_VERB_ARCHIVE_CHARACTER = 7,
+  CORTEX_VERB_BIND_COMPONENT_ROLE = 8,
+  CORTEX_VERB_VALIDATE_COMPONENT = 9,
+  CORTEX_VERB_MARK_COMPONENT_READY = 10,
+  CORTEX_VERB_ACTIVATE_COMPONENT = 11,
+  CORTEX_VERB_CONFIRM_SUBAGENT_SPAWN = 12,
+  CORTEX_VERB_DESPAWN_SUBAGENT = 13,
+  CORTEX_VERB_ARCHIVE_SUBAGENT = 14,
+  CORTEX_VERB_SUSPEND_COMPONENT = 15,
+  CORTEX_VERB_RESUME_COMPONENT = 16,
+  CORTEX_VERB_DEGRADE_COMPONENT = 17,
+  CORTEX_VERB_RESTORE_COMPONENT = 18,
+  CORTEX_VERB_DETACH_COMPONENT = 19,
+  CORTEX_VERB_ARCHIVE_COMPONENT = 20,
+  CORTEX_VERB_SUSPEND_SUBAGENT = 21,
+  CORTEX_VERB_RESUME_SUBAGENT = 22
+} cortex_control_verb;
+
+typedef enum cortex_runtime_error {
+  CORTEX_RUNTIME_OK = 0,
+  CORTEX_ERR_RUNTIME_INVALID_ARGUMENT = 1,
+  CORTEX_ERR_RUNTIME_INVALID_OWNER = 2,
+  CORTEX_ERR_RUNTIME_INVALID_COMPONENT_ROLE = 3,
+  CORTEX_ERR_RUNTIME_DUPLICATE_SLOT = 4,
+  CORTEX_ERR_RUNTIME_UNSUPPORTED_ARRAY_SHAPE = 5,
+  CORTEX_ERR_RUNTIME_INVALID_TRANSITION = 6,
+  CORTEX_ERR_RUNTIME_TARGET_NOT_READY = 7,
+  CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT = 8,
+  CORTEX_ERR_RUNTIME_SUBAGENT_LIMIT_EXCEEDED = 9,
+  CORTEX_ERR_RUNTIME_ARCHIVE_BLOCKED_BY_LIVE_CHILDREN = 10,
+  CORTEX_ERR_RUNTIME_IMPORT_MAPPING_REJECTED = 11
+} cortex_runtime_error;
+
+typedef struct cortex_ara_component {
+  const char *component_id;
+  uint32_t slot_index;
+  cortex_component_role role;
+  const char *owner_identity_ref;
+  cortex_component_state lifecycle_state;
+  uint32_t subagent_limit;
+  uint32_t live_or_queued_subagents;
+} cortex_ara_component;
+
+typedef struct cortex_character {
+  const char *character_id;
+  const char *owner_identity_ref;
+  cortex_ara_shape array_shape;
+  cortex_character_state lifecycle_state;
+  cortex_ara_component *components;
+  size_t component_count;
+} cortex_character;
+
+typedef struct cortex_subagent_instance {
+  const char *subagent_id;
+  const char *definition_ref;
+  size_t component_index;
+  cortex_subagent_state lifecycle_state;
+  uint8_t imported_definition;
+} cortex_subagent_instance;
+
+typedef struct cortex_runtime_result {
+  cortex_runtime_error error;
+  const char *rule_id;
+  const char *message;
+  size_t failing_index;
+} cortex_runtime_result;
+
+uint32_t cortex_character_runtime_abi_version(void);
+uint32_t cortex_character_runtime_descriptor_version(void);
+
+cortex_runtime_error cortex_character_validate(
+  const cortex_character *character,
+  cortex_runtime_result *result);
+
+cortex_runtime_error cortex_character_apply_verb(
+  cortex_character *character,
+  cortex_control_verb verb,
+  cortex_runtime_result *result);
+
+cortex_runtime_error cortex_component_apply_verb(
+  cortex_character *character,
+  size_t component_index,
+  cortex_control_verb verb,
+  cortex_runtime_result *result);
+
+cortex_runtime_error cortex_subagent_bind_imported_helper(
+  cortex_character *character,
+  size_t component_index,
+  const cortex_import_mapping_result *mapping,
+  cortex_subagent_instance *subagent,
+  cortex_runtime_result *result);
+
+cortex_runtime_error cortex_subagent_apply_verb(
+  cortex_subagent_instance *subagent,
+  cortex_control_verb verb,
+  cortex_runtime_result *result);
+
+cortex_runtime_error cortex_subagent_apply_verb_for_component(
+  cortex_character *character,
+  size_t component_index,
+  cortex_subagent_instance *subagent,
+  cortex_control_verb verb,
+  cortex_runtime_result *result);
+
+const char *cortex_character_state_name(cortex_character_state state);
+const char *cortex_component_state_name(cortex_component_state state);
+const char *cortex_subagent_state_name(cortex_subagent_state state);
+const char *cortex_runtime_error_name(cortex_runtime_error error);
+
+#ifdef __cplusplus
+}
+#endif
+
+#endif

--- a/src/character_runtime.c
+++ b/src/character_runtime.c
@@ -1,0 +1,677 @@
+#include "cortex/character_runtime.h"
+
+#define CORTEX_CHARACTER_DESCRIPTOR_VERSION 1u
+
+static int is_empty(const char *value) {
+  return value == 0 || value[0] == '\0';
+}
+
+static uint32_t component_limit(const cortex_ara_component *component) {
+  return component->subagent_limit == 0u ? CORTEX_DEFAULT_SUBAGENT_LIMIT : component->subagent_limit;
+}
+
+static void clear_result(cortex_runtime_result *result) {
+  if (result == 0) {
+    return;
+  }
+
+  result->error = CORTEX_ERR_RUNTIME_INVALID_ARGUMENT;
+  result->rule_id = "invalid_argument";
+  result->message = "invalid runtime argument";
+  result->failing_index = 0u;
+}
+
+static cortex_runtime_error finish(
+  cortex_runtime_result *result,
+  cortex_runtime_error error,
+  const char *rule_id,
+  const char *message,
+  size_t failing_index) {
+  if (result != 0) {
+    result->error = error;
+    result->rule_id = rule_id;
+    result->message = message;
+    result->failing_index = failing_index;
+  }
+
+  return error;
+}
+
+static int is_valid_role(cortex_component_role role) {
+  return role == CORTEX_COMPONENT_ROLE_ACTIVE ||
+         role == CORTEX_COMPONENT_ROLE_MEMORY ||
+         role == CORTEX_COMPONENT_ROLE_REASONING;
+}
+
+static int component_can_mark_ready(cortex_component_state state) {
+  return state == CORTEX_COMPONENT_VALIDATED ||
+         state == CORTEX_COMPONENT_READY ||
+         state == CORTEX_COMPONENT_ACTIVE;
+}
+
+static int component_can_activate_with_character(cortex_component_state state) {
+  return state == CORTEX_COMPONENT_READY || state == CORTEX_COMPONENT_ACTIVE;
+}
+
+static int component_allows_subagent_queue(cortex_component_state state) {
+  return state == CORTEX_COMPONENT_READY ||
+         state == CORTEX_COMPONENT_ACTIVE ||
+         state == CORTEX_COMPONENT_DEGRADED;
+}
+
+static int subagent_is_live_child(cortex_subagent_state state) {
+  return state == CORTEX_SUBAGENT_QUEUED ||
+         state == CORTEX_SUBAGENT_ACTIVE ||
+         state == CORTEX_SUBAGENT_SUSPENDED;
+}
+
+static int character_has_live_children(const cortex_character *character) {
+  size_t index = 0u;
+
+  for (index = 0u; index < character->component_count; ++index) {
+    if (character->components[index].live_or_queued_subagents > 0u) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+static int expected_component_count(cortex_ara_shape shape, size_t actual_count) {
+  if (shape == CORTEX_ARA_SHAPE_TWO_COMPONENT) {
+    return actual_count == 2u;
+  }
+
+  if (shape == CORTEX_ARA_SHAPE_THREE_COMPONENT) {
+    return actual_count == 3u;
+  }
+
+  if (shape == CORTEX_ARA_SHAPE_LARGER_JUSTIFIED) {
+    return actual_count > 3u;
+  }
+
+  return 0;
+}
+
+static int has_role(const cortex_character *character, cortex_component_role role) {
+  size_t index = 0u;
+
+  for (index = 0u; index < character->component_count; ++index) {
+    if (character->components[index].role == role) {
+      return 1;
+    }
+  }
+
+  return 0;
+}
+
+static int has_required_role_set(const cortex_character *character) {
+  if (character->array_shape == CORTEX_ARA_SHAPE_TWO_COMPONENT) {
+    return has_role(character, CORTEX_COMPONENT_ROLE_ACTIVE) &&
+           has_role(character, CORTEX_COMPONENT_ROLE_MEMORY);
+  }
+
+  if (character->array_shape == CORTEX_ARA_SHAPE_THREE_COMPONENT) {
+    return has_role(character, CORTEX_COMPONENT_ROLE_ACTIVE) &&
+           has_role(character, CORTEX_COMPONENT_ROLE_MEMORY) &&
+           has_role(character, CORTEX_COMPONENT_ROLE_REASONING);
+  }
+
+  return 1;
+}
+
+uint32_t cortex_character_runtime_abi_version(void) {
+  return (CORTEX_CHARACTER_RUNTIME_ABI_VERSION_MAJOR << 16) |
+         (CORTEX_CHARACTER_RUNTIME_ABI_VERSION_MINOR << 8) |
+         CORTEX_CHARACTER_RUNTIME_ABI_VERSION_PATCH;
+}
+
+uint32_t cortex_character_runtime_descriptor_version(void) {
+  return CORTEX_CHARACTER_DESCRIPTOR_VERSION;
+}
+
+cortex_runtime_error cortex_character_validate(
+  const cortex_character *character,
+  cortex_runtime_result *result) {
+  size_t left = 0u;
+  size_t right = 0u;
+
+  clear_result(result);
+
+  if (character == 0 || character->components == 0 || character->component_count == 0u) {
+    return finish(result, CORTEX_ERR_RUNTIME_INVALID_ARGUMENT,
+                  "character_required",
+                  "character and component descriptors are required", 0u);
+  }
+
+  if (is_empty(character->character_id) || is_empty(character->owner_identity_ref)) {
+    return finish(result, CORTEX_ERR_RUNTIME_INVALID_OWNER,
+                  "character_owner_required",
+                  "character id and owner identity are required", 0u);
+  }
+
+  if (!expected_component_count(character->array_shape, character->component_count)) {
+    return finish(result, CORTEX_ERR_RUNTIME_UNSUPPORTED_ARRAY_SHAPE,
+                  "array_shape_unsupported",
+                  "array shape must match two-component, three-component, or justified larger count", 0u);
+  }
+
+  for (left = 0u; left < character->component_count; ++left) {
+    const cortex_ara_component *component = &character->components[left];
+
+    if (is_empty(component->component_id) || is_empty(component->owner_identity_ref)) {
+      return finish(result, CORTEX_ERR_RUNTIME_INVALID_OWNER,
+                    "component_owner_required",
+                    "component id and owner identity are required", left);
+    }
+
+    if (!is_valid_role(component->role)) {
+      return finish(result, CORTEX_ERR_RUNTIME_INVALID_COMPONENT_ROLE,
+                    "component_role_invalid",
+                    "component role must be active, memory, or reasoning", left);
+    }
+
+    if (component->live_or_queued_subagents > component_limit(component)) {
+      return finish(result, CORTEX_ERR_RUNTIME_SUBAGENT_LIMIT_EXCEEDED,
+                    "component_subagent_limit_exceeded",
+                    "component has more live or queued subagents than its limit", left);
+    }
+
+    for (right = left + 1u; right < character->component_count; ++right) {
+      if (component->slot_index == character->components[right].slot_index) {
+        return finish(result, CORTEX_ERR_RUNTIME_DUPLICATE_SLOT,
+                      "component_slot_duplicate",
+                      "component slot indexes must be unique", right);
+      }
+    }
+  }
+
+  if (!has_required_role_set(character)) {
+    return finish(result, CORTEX_ERR_RUNTIME_INVALID_COMPONENT_ROLE,
+                  "array_required_roles_missing",
+                  "two-component ARAs require active and memory roles; three-component ARAs also require reasoning",
+                  0u);
+  }
+
+  return finish(result, CORTEX_RUNTIME_OK,
+                "character_validated",
+                "character, component, and array descriptors are valid", 0u);
+}
+
+cortex_runtime_error cortex_character_apply_verb(
+  cortex_character *character,
+  cortex_control_verb verb,
+  cortex_runtime_result *result) {
+  cortex_runtime_error validation = CORTEX_RUNTIME_OK;
+  size_t index = 0u;
+
+  clear_result(result);
+
+  if (character == 0) {
+    return finish(result, CORTEX_ERR_RUNTIME_INVALID_ARGUMENT,
+                  "character_required",
+                  "character descriptor is required", 0u);
+  }
+
+  if (verb == CORTEX_VERB_VALIDATE_CHARACTER) {
+    validation = cortex_character_validate(character, result);
+    if (validation != CORTEX_RUNTIME_OK) {
+      return validation;
+    }
+    character->lifecycle_state = CORTEX_CHARACTER_VALIDATED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "character_validated",
+                  "character moved to validated", 0u);
+  }
+
+  if (verb == CORTEX_VERB_MARK_READY) {
+    if (character->lifecycle_state != CORTEX_CHARACTER_VALIDATED) {
+      return finish(result, CORTEX_ERR_RUNTIME_INVALID_TRANSITION,
+                    "character_ready_requires_validated",
+                    "character must be validated before ready", 0u);
+    }
+
+    for (index = 0u; index < character->component_count; ++index) {
+      if (!component_can_mark_ready(character->components[index].lifecycle_state)) {
+        return finish(result, CORTEX_ERR_RUNTIME_TARGET_NOT_READY,
+                      "component_not_ready",
+                      "all components must be validated or ready before character ready", index);
+      }
+    }
+
+    character->lifecycle_state = CORTEX_CHARACTER_READY;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "character_marked_ready",
+                  "character moved to ready", 0u);
+  }
+
+  if (verb == CORTEX_VERB_ACTIVATE_CHARACTER) {
+    if (character->lifecycle_state != CORTEX_CHARACTER_READY) {
+      return finish(result, CORTEX_ERR_RUNTIME_INVALID_TRANSITION,
+                    "character_activate_requires_ready",
+                    "character must be ready before activation", 0u);
+    }
+
+    for (index = 0u; index < character->component_count; ++index) {
+      if (!component_can_activate_with_character(character->components[index].lifecycle_state)) {
+        return finish(result, CORTEX_ERR_RUNTIME_TARGET_NOT_READY,
+                      "component_activation_not_ready",
+                      "all required components must be ready before activation", index);
+      }
+    }
+
+    character->lifecycle_state = CORTEX_CHARACTER_ACTIVE;
+    for (index = 0u; index < character->component_count; ++index) {
+      character->components[index].lifecycle_state = CORTEX_COMPONENT_ACTIVE;
+    }
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "character_activated",
+                  "character and ready components moved to active", 0u);
+  }
+
+  if (verb == CORTEX_VERB_SUSPEND_CHARACTER &&
+      (character->lifecycle_state == CORTEX_CHARACTER_ACTIVE ||
+       character->lifecycle_state == CORTEX_CHARACTER_DEGRADED)) {
+    character->lifecycle_state = CORTEX_CHARACTER_SUSPENDED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "character_suspended",
+                  "character moved to suspended", 0u);
+  }
+
+  if (verb == CORTEX_VERB_RESUME_CHARACTER &&
+      character->lifecycle_state == CORTEX_CHARACTER_SUSPENDED) {
+    character->lifecycle_state = CORTEX_CHARACTER_ACTIVE;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "character_resumed",
+                  "character moved to active", 0u);
+  }
+
+  if (verb == CORTEX_VERB_DEGRADE_CHARACTER &&
+      character->lifecycle_state == CORTEX_CHARACTER_ACTIVE) {
+    character->lifecycle_state = CORTEX_CHARACTER_DEGRADED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "character_degraded",
+                  "character moved to degraded", 0u);
+  }
+
+  if (verb == CORTEX_VERB_RESTORE_CHARACTER &&
+      character->lifecycle_state == CORTEX_CHARACTER_DEGRADED) {
+    character->lifecycle_state = CORTEX_CHARACTER_ACTIVE;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "character_restored",
+                  "character moved to active", 0u);
+  }
+
+  if (verb == CORTEX_VERB_ARCHIVE_CHARACTER) {
+    if (character_has_live_children(character)) {
+      return finish(result, CORTEX_ERR_RUNTIME_ARCHIVE_BLOCKED_BY_LIVE_CHILDREN,
+                    "archive_blocked_by_live_children",
+                    "character cannot archive while components have live or queued subagents", 0u);
+    }
+
+    character->lifecycle_state = CORTEX_CHARACTER_ARCHIVED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "character_archived",
+                  "character moved to archived", 0u);
+  }
+
+  return finish(result, CORTEX_ERR_RUNTIME_INVALID_TRANSITION,
+                "character_transition_invalid",
+                "requested character transition is not legal from the current state", 0u);
+}
+
+cortex_runtime_error cortex_component_apply_verb(
+  cortex_character *character,
+  size_t component_index,
+  cortex_control_verb verb,
+  cortex_runtime_result *result) {
+  cortex_ara_component *component = 0;
+
+  clear_result(result);
+
+  if (character == 0 || character->components == 0 || component_index >= character->component_count) {
+    return finish(result, CORTEX_ERR_RUNTIME_INVALID_ARGUMENT,
+                  "component_required",
+                  "component index must resolve inside the character", component_index);
+  }
+
+  component = &character->components[component_index];
+
+  if (verb == CORTEX_VERB_BIND_COMPONENT_ROLE && component->lifecycle_state == CORTEX_COMPONENT_STAGED) {
+    if (!is_valid_role(component->role) || is_empty(component->owner_identity_ref)) {
+      return finish(result, CORTEX_ERR_RUNTIME_INVALID_COMPONENT_ROLE,
+                    "component_bind_invalid",
+                    "component role and owner must be valid before binding", component_index);
+    }
+    component->lifecycle_state = CORTEX_COMPONENT_BOUND;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_bound",
+                  "component role binding accepted", component_index);
+  }
+
+  if (verb == CORTEX_VERB_VALIDATE_COMPONENT && component->lifecycle_state == CORTEX_COMPONENT_BOUND) {
+    if (component->live_or_queued_subagents > component_limit(component)) {
+      return finish(result, CORTEX_ERR_RUNTIME_SUBAGENT_LIMIT_EXCEEDED,
+                    "component_subagent_limit_exceeded",
+                    "component exceeds subagent limit", component_index);
+    }
+    component->lifecycle_state = CORTEX_COMPONENT_VALIDATED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_validated",
+                  "component moved to validated", component_index);
+  }
+
+  if (verb == CORTEX_VERB_MARK_COMPONENT_READY &&
+      component->lifecycle_state == CORTEX_COMPONENT_VALIDATED) {
+    component->lifecycle_state = CORTEX_COMPONENT_READY;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_ready",
+                  "component moved to ready", component_index);
+  }
+
+  if (verb == CORTEX_VERB_ACTIVATE_COMPONENT && component->lifecycle_state == CORTEX_COMPONENT_READY) {
+    if (character->lifecycle_state != CORTEX_CHARACTER_READY &&
+        character->lifecycle_state != CORTEX_CHARACTER_ACTIVE) {
+      return finish(result, CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT,
+                    "component_parent_not_ready",
+                    "parent character must be ready or active before component activation", component_index);
+    }
+    component->lifecycle_state = CORTEX_COMPONENT_ACTIVE;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_activated",
+                  "component moved to active", component_index);
+  }
+
+  if (verb == CORTEX_VERB_SUSPEND_COMPONENT && component->lifecycle_state == CORTEX_COMPONENT_ACTIVE) {
+    component->lifecycle_state = CORTEX_COMPONENT_SUSPENDED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_suspended",
+                  "component moved to suspended", component_index);
+  }
+
+  if (verb == CORTEX_VERB_RESUME_COMPONENT && component->lifecycle_state == CORTEX_COMPONENT_SUSPENDED) {
+    if (character->lifecycle_state != CORTEX_CHARACTER_READY &&
+        character->lifecycle_state != CORTEX_CHARACTER_ACTIVE) {
+      return finish(result, CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT,
+                    "component_parent_not_resumable",
+                    "parent character must be ready or active before component resume", component_index);
+    }
+    component->lifecycle_state = CORTEX_COMPONENT_ACTIVE;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_resumed",
+                  "component moved to active", component_index);
+  }
+
+  if (verb == CORTEX_VERB_DEGRADE_COMPONENT && component->lifecycle_state == CORTEX_COMPONENT_ACTIVE) {
+    component->lifecycle_state = CORTEX_COMPONENT_DEGRADED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_degraded",
+                  "component moved to degraded", component_index);
+  }
+
+  if (verb == CORTEX_VERB_RESTORE_COMPONENT && component->lifecycle_state == CORTEX_COMPONENT_DEGRADED) {
+    if (character->lifecycle_state != CORTEX_CHARACTER_READY &&
+        character->lifecycle_state != CORTEX_CHARACTER_ACTIVE &&
+        character->lifecycle_state != CORTEX_CHARACTER_DEGRADED) {
+      return finish(result, CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT,
+                    "component_parent_not_restorable",
+                    "parent character must be ready, active, or degraded before component restore", component_index);
+    }
+    component->lifecycle_state = CORTEX_COMPONENT_ACTIVE;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_restored",
+                  "component moved to active", component_index);
+  }
+
+  if (verb == CORTEX_VERB_DETACH_COMPONENT && component->lifecycle_state != CORTEX_COMPONENT_ARCHIVED) {
+    if (component->live_or_queued_subagents != 0u) {
+      return finish(result, CORTEX_ERR_RUNTIME_ARCHIVE_BLOCKED_BY_LIVE_CHILDREN,
+                    "component_detach_blocked_by_live_children",
+                    "component cannot detach while subagents are live or queued", component_index);
+    }
+    component->lifecycle_state = CORTEX_COMPONENT_DETACHED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_detached",
+                  "component moved to detached", component_index);
+  }
+
+  if (verb == CORTEX_VERB_ARCHIVE_COMPONENT && component->lifecycle_state != CORTEX_COMPONENT_ARCHIVED) {
+    if (component->live_or_queued_subagents != 0u) {
+      return finish(result, CORTEX_ERR_RUNTIME_ARCHIVE_BLOCKED_BY_LIVE_CHILDREN,
+                    "component_archive_blocked_by_live_children",
+                    "component cannot archive while subagents are live or queued", component_index);
+    }
+    component->lifecycle_state = CORTEX_COMPONENT_ARCHIVED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "component_archived",
+                  "component moved to archived", component_index);
+  }
+
+  return finish(result, CORTEX_ERR_RUNTIME_INVALID_TRANSITION,
+                "component_transition_invalid",
+                "requested component transition is not legal from the current state", component_index);
+}
+
+cortex_runtime_error cortex_subagent_bind_imported_helper(
+  cortex_character *character,
+  size_t component_index,
+  const cortex_import_mapping_result *mapping,
+  cortex_subagent_instance *subagent,
+  cortex_runtime_result *result) {
+  cortex_ara_component *component = 0;
+
+  clear_result(result);
+
+  if (character == 0 || character->components == 0 ||
+      component_index >= character->component_count ||
+      mapping == 0 || subagent == 0) {
+    return finish(result, CORTEX_ERR_RUNTIME_INVALID_ARGUMENT,
+                  "subagent_bind_arguments_required",
+                  "character, component, mapping, and subagent descriptors are required", component_index);
+  }
+
+  component = &character->components[component_index];
+
+  if (subagent->lifecycle_state != CORTEX_SUBAGENT_DEFINED) {
+    return finish(result, CORTEX_ERR_RUNTIME_INVALID_TRANSITION,
+                  "subagent_bind_requires_defined",
+                  "only defined subagents can bind an imported helper", component_index);
+  }
+
+  if (mapping->error != CORTEX_IMPORT_OK ||
+      mapping->surface != CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION ||
+      mapping->definition_only == 0u ||
+      mapping->can_bind_as_subagent == 0u) {
+    return finish(result, CORTEX_ERR_RUNTIME_IMPORT_MAPPING_REJECTED,
+                  "import_mapping_not_bindable",
+                  "only accepted imported helper definitions may bind as subagent instances", component_index);
+  }
+
+  if (!component_allows_subagent_queue(component->lifecycle_state)) {
+    return finish(result, CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT,
+                  "component_state_blocks_subagent_queue",
+                  "component must be ready, active, or degraded before queueing subagents", component_index);
+  }
+
+  if (component->live_or_queued_subagents >= component_limit(component)) {
+    return finish(result, CORTEX_ERR_RUNTIME_SUBAGENT_LIMIT_EXCEEDED,
+                  "component_subagent_limit_exceeded",
+                  "component cannot queue another governed subagent", component_index);
+  }
+
+  subagent->definition_ref = mapping->descriptor_id;
+  subagent->component_index = component_index;
+  subagent->lifecycle_state = CORTEX_SUBAGENT_QUEUED;
+  subagent->imported_definition = 1u;
+  component->live_or_queued_subagents += 1u;
+
+  return finish(result, CORTEX_RUNTIME_OK,
+                "imported_helper_queued",
+                "imported helper became runtime-relevant through a governed SubagentInstance", component_index);
+}
+
+static cortex_runtime_error apply_subagent_verb(
+  cortex_subagent_instance *subagent,
+  cortex_control_verb verb,
+  cortex_runtime_result *result,
+  int allow_owned_despawn) {
+  clear_result(result);
+
+  if (subagent == 0) {
+    return finish(result, CORTEX_ERR_RUNTIME_INVALID_ARGUMENT,
+                  "subagent_required",
+                  "subagent descriptor is required", 0u);
+  }
+
+  if (verb == CORTEX_VERB_CONFIRM_SUBAGENT_SPAWN &&
+      subagent->lifecycle_state == CORTEX_SUBAGENT_QUEUED) {
+    subagent->lifecycle_state = CORTEX_SUBAGENT_ACTIVE;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "subagent_spawn_confirmed",
+                  "subagent moved to active", subagent->component_index);
+  }
+
+  if (verb == CORTEX_VERB_DESPAWN_SUBAGENT &&
+      subagent_is_live_child(subagent->lifecycle_state)) {
+    if (!allow_owned_despawn) {
+      return finish(result, CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT,
+                    "subagent_component_context_required",
+                    "owned subagent despawn requires component context", subagent->component_index);
+    }
+    subagent->lifecycle_state = CORTEX_SUBAGENT_DESPAWNED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "subagent_despawned",
+                  "subagent moved to despawned", subagent->component_index);
+  }
+
+  if (verb == CORTEX_VERB_SUSPEND_SUBAGENT &&
+      subagent->lifecycle_state == CORTEX_SUBAGENT_ACTIVE) {
+    subagent->lifecycle_state = CORTEX_SUBAGENT_SUSPENDED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "subagent_suspended",
+                  "subagent moved to suspended", subagent->component_index);
+  }
+
+  if (verb == CORTEX_VERB_RESUME_SUBAGENT &&
+      subagent->lifecycle_state == CORTEX_SUBAGENT_SUSPENDED) {
+    subagent->lifecycle_state = CORTEX_SUBAGENT_ACTIVE;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "subagent_resumed",
+                  "subagent moved to active", subagent->component_index);
+  }
+
+  if (verb == CORTEX_VERB_ARCHIVE_SUBAGENT &&
+      (subagent->lifecycle_state == CORTEX_SUBAGENT_DESPAWNED ||
+       subagent->lifecycle_state == CORTEX_SUBAGENT_DEFINED)) {
+    subagent->lifecycle_state = CORTEX_SUBAGENT_ARCHIVED;
+    return finish(result, CORTEX_RUNTIME_OK,
+                  "subagent_archived",
+                  "subagent moved to archived", subagent->component_index);
+  }
+
+  return finish(result, CORTEX_ERR_RUNTIME_INVALID_TRANSITION,
+                "subagent_transition_invalid",
+                "requested subagent transition is not legal from the current state", subagent->component_index);
+}
+
+cortex_runtime_error cortex_subagent_apply_verb(
+  cortex_subagent_instance *subagent,
+  cortex_control_verb verb,
+  cortex_runtime_result *result) {
+  return apply_subagent_verb(subagent, verb, result, 0);
+}
+
+cortex_runtime_error cortex_subagent_apply_verb_for_component(
+  cortex_character *character,
+  size_t component_index,
+  cortex_subagent_instance *subagent,
+  cortex_control_verb verb,
+  cortex_runtime_result *result) {
+  cortex_runtime_error outcome = CORTEX_RUNTIME_OK;
+  cortex_ara_component *component = 0;
+  cortex_subagent_state before = CORTEX_SUBAGENT_DEFINED;
+
+  clear_result(result);
+
+  if (character == 0 || character->components == 0 ||
+      component_index >= character->component_count ||
+      subagent == 0 ||
+      subagent->component_index != component_index) {
+    return finish(result, CORTEX_ERR_RUNTIME_INVALID_ARGUMENT,
+                  "subagent_component_context_required",
+                  "subagent transition requires a matching owning component", component_index);
+  }
+
+  component = &character->components[component_index];
+  before = subagent->lifecycle_state;
+  outcome = apply_subagent_verb(subagent, verb, result, 1);
+
+  if (outcome == CORTEX_RUNTIME_OK &&
+      verb == CORTEX_VERB_DESPAWN_SUBAGENT &&
+      subagent_is_live_child(before) &&
+      component->live_or_queued_subagents > 0u) {
+    component->live_or_queued_subagents -= 1u;
+  }
+
+  return outcome;
+}
+
+const char *cortex_character_state_name(cortex_character_state state) {
+  switch (state) {
+    case CORTEX_CHARACTER_DRAFT: return "draft";
+    case CORTEX_CHARACTER_ASSEMBLING: return "assembling";
+    case CORTEX_CHARACTER_VALIDATED: return "validated";
+    case CORTEX_CHARACTER_READY: return "ready";
+    case CORTEX_CHARACTER_ACTIVE: return "active";
+    case CORTEX_CHARACTER_SUSPENDED: return "suspended";
+    case CORTEX_CHARACTER_DEGRADED: return "degraded";
+    case CORTEX_CHARACTER_ARCHIVED: return "archived";
+    default: return "unknown";
+  }
+}
+
+const char *cortex_component_state_name(cortex_component_state state) {
+  switch (state) {
+    case CORTEX_COMPONENT_STAGED: return "staged";
+    case CORTEX_COMPONENT_BOUND: return "bound";
+    case CORTEX_COMPONENT_VALIDATED: return "validated";
+    case CORTEX_COMPONENT_READY: return "ready";
+    case CORTEX_COMPONENT_ACTIVE: return "active";
+    case CORTEX_COMPONENT_SUSPENDED: return "suspended";
+    case CORTEX_COMPONENT_DEGRADED: return "degraded";
+    case CORTEX_COMPONENT_DETACHED: return "detached";
+    case CORTEX_COMPONENT_ARCHIVED: return "archived";
+    default: return "unknown";
+  }
+}
+
+const char *cortex_subagent_state_name(cortex_subagent_state state) {
+  switch (state) {
+    case CORTEX_SUBAGENT_DEFINED: return "defined";
+    case CORTEX_SUBAGENT_QUEUED: return "queued";
+    case CORTEX_SUBAGENT_ACTIVE: return "active";
+    case CORTEX_SUBAGENT_SUSPENDED: return "suspended";
+    case CORTEX_SUBAGENT_DESPAWNED: return "despawned";
+    case CORTEX_SUBAGENT_ARCHIVED: return "archived";
+    default: return "unknown";
+  }
+}
+
+const char *cortex_runtime_error_name(cortex_runtime_error error) {
+  switch (error) {
+    case CORTEX_RUNTIME_OK: return "CORTEX_RUNTIME_OK";
+    case CORTEX_ERR_RUNTIME_INVALID_ARGUMENT: return "CORTEX_ERR_RUNTIME_INVALID_ARGUMENT";
+    case CORTEX_ERR_RUNTIME_INVALID_OWNER: return "CORTEX_ERR_RUNTIME_INVALID_OWNER";
+    case CORTEX_ERR_RUNTIME_INVALID_COMPONENT_ROLE: return "CORTEX_ERR_RUNTIME_INVALID_COMPONENT_ROLE";
+    case CORTEX_ERR_RUNTIME_DUPLICATE_SLOT: return "CORTEX_ERR_RUNTIME_DUPLICATE_SLOT";
+    case CORTEX_ERR_RUNTIME_UNSUPPORTED_ARRAY_SHAPE: return "CORTEX_ERR_RUNTIME_UNSUPPORTED_ARRAY_SHAPE";
+    case CORTEX_ERR_RUNTIME_INVALID_TRANSITION: return "CORTEX_ERR_RUNTIME_INVALID_TRANSITION";
+    case CORTEX_ERR_RUNTIME_TARGET_NOT_READY: return "CORTEX_ERR_RUNTIME_TARGET_NOT_READY";
+    case CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT: return "CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT";
+    case CORTEX_ERR_RUNTIME_SUBAGENT_LIMIT_EXCEEDED: return "CORTEX_ERR_RUNTIME_SUBAGENT_LIMIT_EXCEEDED";
+    case CORTEX_ERR_RUNTIME_ARCHIVE_BLOCKED_BY_LIVE_CHILDREN:
+      return "CORTEX_ERR_RUNTIME_ARCHIVE_BLOCKED_BY_LIVE_CHILDREN";
+    case CORTEX_ERR_RUNTIME_IMPORT_MAPPING_REJECTED: return "CORTEX_ERR_RUNTIME_IMPORT_MAPPING_REJECTED";
+    default: return "CORTEX_ERR_RUNTIME_UNKNOWN";
+  }
+}

--- a/src/imported_catalog_mapper.c
+++ b/src/imported_catalog_mapper.c
@@ -104,7 +104,9 @@ static cortex_import_error finish(
     result->definition_only = surface == CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION ? 1u : 0u;
     result->can_bind_as_subagent =
       surface == CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION &&
-      outcome == CORTEX_IMPORT_OUTCOME_ACCEPTED ? 1u : 0u;
+      error == CORTEX_IMPORT_OK &&
+      (outcome == CORTEX_IMPORT_OUTCOME_ACCEPTED ||
+       outcome == CORTEX_IMPORT_OUTCOME_NARROWED) ? 1u : 0u;
   }
 
   return error;

--- a/tests/test_character_runtime.c
+++ b/tests/test_character_runtime.c
@@ -1,0 +1,458 @@
+#include "cortex/character_runtime.h"
+
+#include <stdio.h>
+#include <string.h>
+
+static int failures = 0;
+
+#define CHECK(condition) \
+  do { \
+    if (!(condition)) { \
+      fprintf(stderr, "CHECK failed at %s:%d: %s\n", __FILE__, __LINE__, #condition); \
+      ++failures; \
+    } \
+  } while (0)
+
+static cortex_character make_two_component_character(cortex_ara_component components[2]) {
+  cortex_character character;
+
+  components[0].component_id = "component-active";
+  components[0].slot_index = 0u;
+  components[0].role = CORTEX_COMPONENT_ROLE_ACTIVE;
+  components[0].owner_identity_ref = "symbiote-primary";
+  components[0].lifecycle_state = CORTEX_COMPONENT_READY;
+  components[0].subagent_limit = CORTEX_DEFAULT_SUBAGENT_LIMIT;
+  components[0].live_or_queued_subagents = 0u;
+
+  components[1].component_id = "component-memory";
+  components[1].slot_index = 1u;
+  components[1].role = CORTEX_COMPONENT_ROLE_MEMORY;
+  components[1].owner_identity_ref = "curator-memory";
+  components[1].lifecycle_state = CORTEX_COMPONENT_READY;
+  components[1].subagent_limit = CORTEX_DEFAULT_SUBAGENT_LIMIT;
+  components[1].live_or_queued_subagents = 0u;
+
+  character.character_id = "character-alpha";
+  character.owner_identity_ref = "symbiote-primary";
+  character.array_shape = CORTEX_ARA_SHAPE_TWO_COMPONENT;
+  character.lifecycle_state = CORTEX_CHARACTER_DRAFT;
+  character.components = components;
+  character.component_count = 2u;
+  return character;
+}
+
+static cortex_import_mapping_result accepted_helper_mapping(void) {
+  cortex_import_mapping_result mapping;
+
+  mapping.surface = CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION;
+  mapping.outcome = CORTEX_IMPORT_OUTCOME_ACCEPTED;
+  mapping.lifecycle_state = CORTEX_IMPORT_LIFECYCLE_STAGED;
+  mapping.error = CORTEX_IMPORT_OK;
+  mapping.descriptor_id = "helper-empathy-v2";
+  mapping.source_registration_ref = "catalog-entry-1";
+  mapping.rule_id = "helper_definition_accepted";
+  mapping.message = "accepted helper";
+  mapping.descriptor_version = cortex_imported_catalog_descriptor_version();
+  mapping.definition_only = 1u;
+  mapping.can_bind_as_subagent = 1u;
+  return mapping;
+}
+
+static void validates_and_activates_two_component_character(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_runtime_result result;
+
+  CHECK(cortex_character_runtime_abi_version() == 0x00010000u);
+  CHECK(cortex_character_runtime_descriptor_version() == 1u);
+  CHECK(cortex_character_validate(&character, &result) == CORTEX_RUNTIME_OK);
+  CHECK(strcmp(result.rule_id, "character_validated") == 0);
+  CHECK(cortex_character_apply_verb(&character, CORTEX_VERB_VALIDATE_CHARACTER, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(character.lifecycle_state == CORTEX_CHARACTER_VALIDATED);
+  CHECK(cortex_character_apply_verb(&character, CORTEX_VERB_MARK_READY, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(character.lifecycle_state == CORTEX_CHARACTER_READY);
+  CHECK(cortex_character_apply_verb(&character, CORTEX_VERB_ACTIVATE_CHARACTER, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(character.lifecycle_state == CORTEX_CHARACTER_ACTIVE);
+  CHECK(components[0].lifecycle_state == CORTEX_COMPONENT_ACTIVE);
+  CHECK(components[1].lifecycle_state == CORTEX_COMPONENT_ACTIVE);
+}
+
+static void validates_three_component_character(void) {
+  cortex_ara_component components[3];
+  cortex_character character;
+  cortex_runtime_result result;
+
+  (void)make_two_component_character(components);
+  components[2].component_id = "component-reasoning";
+  components[2].slot_index = 2u;
+  components[2].role = CORTEX_COMPONENT_ROLE_REASONING;
+  components[2].owner_identity_ref = "symbiote-primary";
+  components[2].lifecycle_state = CORTEX_COMPONENT_READY;
+  components[2].subagent_limit = CORTEX_DEFAULT_SUBAGENT_LIMIT;
+  components[2].live_or_queued_subagents = 0u;
+
+  character.character_id = "character-beta";
+  character.owner_identity_ref = "symbiote-primary";
+  character.array_shape = CORTEX_ARA_SHAPE_THREE_COMPONENT;
+  character.lifecycle_state = CORTEX_CHARACTER_DRAFT;
+  character.components = components;
+  character.component_count = 3u;
+
+  CHECK(cortex_character_validate(&character, &result) == CORTEX_RUNTIME_OK);
+}
+
+static void rejects_duplicate_slot_without_mutation(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_runtime_result result;
+
+  components[1].slot_index = 0u;
+
+  CHECK(cortex_character_validate(&character, &result) == CORTEX_ERR_RUNTIME_DUPLICATE_SLOT);
+  CHECK(character.lifecycle_state == CORTEX_CHARACTER_DRAFT);
+  CHECK(result.failing_index == 1u);
+}
+
+static void rejects_missing_required_role_set(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_runtime_result result;
+
+  components[1].role = CORTEX_COMPONENT_ROLE_ACTIVE;
+
+  CHECK(cortex_character_validate(&character, &result) ==
+        CORTEX_ERR_RUNTIME_INVALID_COMPONENT_ROLE);
+  CHECK(strcmp(result.rule_id, "array_required_roles_missing") == 0);
+  CHECK(character.lifecycle_state == CORTEX_CHARACTER_DRAFT);
+}
+
+static void rejects_invalid_transition_without_mutation(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_runtime_result result;
+
+  CHECK(cortex_character_apply_verb(&character, CORTEX_VERB_ACTIVATE_CHARACTER, &result) ==
+        CORTEX_ERR_RUNTIME_INVALID_TRANSITION);
+  CHECK(character.lifecycle_state == CORTEX_CHARACTER_DRAFT);
+}
+
+static void rejects_component_activation_when_parent_not_ready(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_runtime_result result;
+
+  CHECK(cortex_component_apply_verb(&character, 0u, CORTEX_VERB_ACTIVATE_COMPONENT, &result) ==
+        CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT);
+  CHECK(components[0].lifecycle_state == CORTEX_COMPONENT_READY);
+}
+
+static void transitions_component_suspend_degrade_detach_archive(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_runtime_result result;
+
+  character.lifecycle_state = CORTEX_CHARACTER_ACTIVE;
+  components[0].lifecycle_state = CORTEX_COMPONENT_ACTIVE;
+
+  CHECK(cortex_component_apply_verb(&character, 0u, CORTEX_VERB_SUSPEND_COMPONENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(components[0].lifecycle_state == CORTEX_COMPONENT_SUSPENDED);
+  CHECK(cortex_component_apply_verb(&character, 0u, CORTEX_VERB_RESUME_COMPONENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(components[0].lifecycle_state == CORTEX_COMPONENT_ACTIVE);
+  CHECK(cortex_component_apply_verb(&character, 0u, CORTEX_VERB_DEGRADE_COMPONENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(components[0].lifecycle_state == CORTEX_COMPONENT_DEGRADED);
+  CHECK(cortex_component_apply_verb(&character, 0u, CORTEX_VERB_RESTORE_COMPONENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(components[0].lifecycle_state == CORTEX_COMPONENT_ACTIVE);
+  CHECK(cortex_component_apply_verb(&character, 0u, CORTEX_VERB_DETACH_COMPONENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(components[0].lifecycle_state == CORTEX_COMPONENT_DETACHED);
+  CHECK(cortex_component_apply_verb(&character, 0u, CORTEX_VERB_ARCHIVE_COMPONENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(components[0].lifecycle_state == CORTEX_COMPONENT_ARCHIVED);
+}
+
+static void blocks_component_archive_with_live_children(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_runtime_result result;
+
+  components[0].lifecycle_state = CORTEX_COMPONENT_ACTIVE;
+  components[0].live_or_queued_subagents = 1u;
+
+  CHECK(cortex_component_apply_verb(&character, 0u, CORTEX_VERB_ARCHIVE_COMPONENT, &result) ==
+        CORTEX_ERR_RUNTIME_ARCHIVE_BLOCKED_BY_LIVE_CHILDREN);
+  CHECK(components[0].lifecycle_state == CORTEX_COMPONENT_ACTIVE);
+  CHECK(components[0].live_or_queued_subagents == 1u);
+}
+
+static void binds_imported_helper_through_component_only(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_import_mapping_result mapping = accepted_helper_mapping();
+  cortex_subagent_instance subagent;
+  cortex_runtime_result result;
+
+  subagent.subagent_id = "subagent-1";
+  subagent.definition_ref = 0;
+  subagent.component_index = 0u;
+  subagent.lifecycle_state = CORTEX_SUBAGENT_DEFINED;
+  subagent.imported_definition = 0u;
+
+  CHECK(cortex_subagent_bind_imported_helper(&character, 0u, &mapping, &subagent, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_QUEUED);
+  CHECK(subagent.imported_definition == 1u);
+  CHECK(components[0].live_or_queued_subagents == 1u);
+  CHECK(strcmp(subagent.definition_ref, "helper-empathy-v2") == 0);
+}
+
+static void binds_narrowed_imported_helper_through_component(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_import_mapping_result mapping = accepted_helper_mapping();
+  cortex_subagent_instance subagent;
+  cortex_runtime_result result;
+
+  mapping.outcome = CORTEX_IMPORT_OUTCOME_NARROWED;
+  mapping.rule_id = "host_targets_narrowed";
+  mapping.can_bind_as_subagent = 1u;
+  subagent.subagent_id = "subagent-narrowed";
+  subagent.definition_ref = 0;
+  subagent.component_index = 0u;
+  subagent.lifecycle_state = CORTEX_SUBAGENT_DEFINED;
+  subagent.imported_definition = 0u;
+
+  CHECK(cortex_subagent_bind_imported_helper(&character, 0u, &mapping, &subagent, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_QUEUED);
+  CHECK(subagent.imported_definition == 1u);
+  CHECK(components[0].live_or_queued_subagents == 1u);
+}
+
+static void binds_mapper_produced_narrowed_helper_through_component(void) {
+  static const char *host_targets[] = {"codex", "root-shell"};
+  static const char *roles[] = {"active"};
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_catalog_registration registration;
+  cortex_import_mapping_result mapping;
+  cortex_subagent_instance subagent;
+  cortex_runtime_result result;
+
+  memset(&registration, 0, sizeof(registration));
+  registration.registration_id = "catalog-entry-narrowed";
+  registration.source_repo = "JKhyro/SYMBIOSIS";
+  registration.source_path = ".codex/agents/helper.toml";
+  registration.source_commit = "5f855c11f9117541da31e7274b738cc396d4d3c7";
+  registration.runtime_class = "imported-helper";
+  registration.canonical_label = "Imported helper";
+  registration.compatibility_version = "1";
+  registration.host_targets = host_targets;
+  registration.host_target_count = 2u;
+  registration.compatible_component_roles = roles;
+  registration.compatible_component_role_count = 1u;
+
+  subagent.subagent_id = "subagent-mapper-produced-narrowed";
+  subagent.definition_ref = 0;
+  subagent.component_index = 0u;
+  subagent.lifecycle_state = CORTEX_SUBAGENT_DEFINED;
+  subagent.imported_definition = 0u;
+
+  CHECK(cortex_import_map_registration(&registration, &mapping) == CORTEX_IMPORT_OK);
+  CHECK(mapping.outcome == CORTEX_IMPORT_OUTCOME_NARROWED);
+  CHECK(mapping.can_bind_as_subagent == 1u);
+  CHECK(cortex_subagent_bind_imported_helper(&character, 0u, &mapping, &subagent, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_QUEUED);
+  CHECK(components[0].live_or_queued_subagents == 1u);
+}
+
+static void rejects_rejected_import_mapping_without_mutation(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_import_mapping_result mapping = accepted_helper_mapping();
+  cortex_subagent_instance subagent;
+  cortex_runtime_result result;
+
+  mapping.outcome = CORTEX_IMPORT_OUTCOME_REJECTED;
+  mapping.error = CORTEX_ERR_IMPORT_PROMOTION_REQUIRED;
+  mapping.can_bind_as_subagent = 0u;
+  subagent.subagent_id = "subagent-2";
+  subagent.definition_ref = 0;
+  subagent.component_index = 0u;
+  subagent.lifecycle_state = CORTEX_SUBAGENT_DEFINED;
+  subagent.imported_definition = 0u;
+
+  CHECK(cortex_subagent_bind_imported_helper(&character, 0u, &mapping, &subagent, &result) ==
+        CORTEX_ERR_RUNTIME_IMPORT_MAPPING_REJECTED);
+  CHECK(components[0].live_or_queued_subagents == 0u);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_DEFINED);
+}
+
+static void rejects_bind_from_non_defined_subagent_without_mutation(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_import_mapping_result mapping = accepted_helper_mapping();
+  cortex_subagent_instance subagent;
+  cortex_runtime_result result;
+
+  components[0].lifecycle_state = CORTEX_COMPONENT_ACTIVE;
+  subagent.subagent_id = "subagent-live";
+  subagent.definition_ref = "helper-existing";
+  subagent.component_index = 0u;
+  subagent.lifecycle_state = CORTEX_SUBAGENT_ACTIVE;
+  subagent.imported_definition = 1u;
+
+  CHECK(cortex_subagent_bind_imported_helper(&character, 0u, &mapping, &subagent, &result) ==
+        CORTEX_ERR_RUNTIME_INVALID_TRANSITION);
+  CHECK(components[0].live_or_queued_subagents == 0u);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_ACTIVE);
+  CHECK(strcmp(subagent.definition_ref, "helper-existing") == 0);
+}
+
+static void rejects_subagent_over_limit_without_mutation(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_import_mapping_result mapping = accepted_helper_mapping();
+  cortex_subagent_instance subagent;
+  cortex_runtime_result result;
+
+  components[0].live_or_queued_subagents = CORTEX_DEFAULT_SUBAGENT_LIMIT;
+  subagent.subagent_id = "subagent-3";
+  subagent.lifecycle_state = CORTEX_SUBAGENT_DEFINED;
+  subagent.imported_definition = 0u;
+
+  CHECK(cortex_subagent_bind_imported_helper(&character, 0u, &mapping, &subagent, &result) ==
+        CORTEX_ERR_RUNTIME_SUBAGENT_LIMIT_EXCEEDED);
+  CHECK(components[0].live_or_queued_subagents == CORTEX_DEFAULT_SUBAGENT_LIMIT);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_DEFINED);
+}
+
+static void blocks_archive_with_live_children(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_runtime_result result;
+
+  character.lifecycle_state = CORTEX_CHARACTER_ACTIVE;
+  components[0].live_or_queued_subagents = 1u;
+
+  CHECK(cortex_character_apply_verb(&character, CORTEX_VERB_ARCHIVE_CHARACTER, &result) ==
+        CORTEX_ERR_RUNTIME_ARCHIVE_BLOCKED_BY_LIVE_CHILDREN);
+  CHECK(character.lifecycle_state == CORTEX_CHARACTER_ACTIVE);
+}
+
+static void transitions_subagent_spawn_and_archive(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_subagent_instance subagent;
+  cortex_runtime_result result;
+
+  character.lifecycle_state = CORTEX_CHARACTER_ACTIVE;
+  components[0].lifecycle_state = CORTEX_COMPONENT_ACTIVE;
+  components[0].live_or_queued_subagents = 1u;
+  subagent.subagent_id = "subagent-4";
+  subagent.definition_ref = "helper-empathy-v2";
+  subagent.component_index = 0u;
+  subagent.lifecycle_state = CORTEX_SUBAGENT_QUEUED;
+  subagent.imported_definition = 1u;
+
+  CHECK(cortex_subagent_apply_verb(&subagent, CORTEX_VERB_CONFIRM_SUBAGENT_SPAWN, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_ACTIVE);
+  CHECK(cortex_subagent_apply_verb(&subagent, CORTEX_VERB_SUSPEND_SUBAGENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_SUSPENDED);
+  CHECK(cortex_subagent_apply_verb(&subagent, CORTEX_VERB_RESUME_SUBAGENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_ACTIVE);
+  CHECK(cortex_subagent_apply_verb_for_component(&character, 0u, &subagent,
+                                                 CORTEX_VERB_DESPAWN_SUBAGENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_DESPAWNED);
+  CHECK(components[0].live_or_queued_subagents == 0u);
+  CHECK(cortex_subagent_apply_verb(&subagent, CORTEX_VERB_ARCHIVE_SUBAGENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_ARCHIVED);
+}
+
+static void context_free_despawn_requires_component_context(void) {
+  cortex_subagent_instance subagent;
+  cortex_runtime_result result;
+
+  subagent.subagent_id = "subagent-context-required";
+  subagent.definition_ref = "helper-empathy-v2";
+  subagent.component_index = 0u;
+  subagent.lifecycle_state = CORTEX_SUBAGENT_ACTIVE;
+  subagent.imported_definition = 1u;
+
+  CHECK(cortex_subagent_apply_verb(&subagent, CORTEX_VERB_DESPAWN_SUBAGENT, &result) ==
+        CORTEX_ERR_RUNTIME_PARENT_STATE_CONFLICT);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_ACTIVE);
+}
+
+static void subagent_despawn_releases_component_capacity_and_allows_archive(void) {
+  cortex_ara_component components[2];
+  cortex_character character = make_two_component_character(components);
+  cortex_import_mapping_result mapping = accepted_helper_mapping();
+  cortex_subagent_instance subagent;
+  cortex_runtime_result result;
+
+  character.lifecycle_state = CORTEX_CHARACTER_ACTIVE;
+  components[0].lifecycle_state = CORTEX_COMPONENT_ACTIVE;
+  subagent.subagent_id = "subagent-5";
+  subagent.definition_ref = 0;
+  subagent.component_index = 0u;
+  subagent.lifecycle_state = CORTEX_SUBAGENT_DEFINED;
+  subagent.imported_definition = 0u;
+
+  CHECK(cortex_subagent_bind_imported_helper(&character, 0u, &mapping, &subagent, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(components[0].live_or_queued_subagents == 1u);
+  CHECK(cortex_subagent_apply_verb_for_component(&character, 0u, &subagent,
+                                                 CORTEX_VERB_CONFIRM_SUBAGENT_SPAWN, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_ACTIVE);
+  CHECK(cortex_subagent_apply_verb_for_component(&character, 0u, &subagent,
+                                                 CORTEX_VERB_DESPAWN_SUBAGENT, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(subagent.lifecycle_state == CORTEX_SUBAGENT_DESPAWNED);
+  CHECK(components[0].live_or_queued_subagents == 0u);
+  CHECK(cortex_character_apply_verb(&character, CORTEX_VERB_ARCHIVE_CHARACTER, &result) ==
+        CORTEX_RUNTIME_OK);
+  CHECK(character.lifecycle_state == CORTEX_CHARACTER_ARCHIVED);
+}
+
+int main(void) {
+  validates_and_activates_two_component_character();
+  validates_three_component_character();
+  rejects_duplicate_slot_without_mutation();
+  rejects_missing_required_role_set();
+  rejects_invalid_transition_without_mutation();
+  rejects_component_activation_when_parent_not_ready();
+  transitions_component_suspend_degrade_detach_archive();
+  blocks_component_archive_with_live_children();
+  binds_imported_helper_through_component_only();
+  binds_narrowed_imported_helper_through_component();
+  binds_mapper_produced_narrowed_helper_through_component();
+  rejects_rejected_import_mapping_without_mutation();
+  rejects_bind_from_non_defined_subagent_without_mutation();
+  rejects_subagent_over_limit_without_mutation();
+  blocks_archive_with_live_children();
+  transitions_subagent_spawn_and_archive();
+  context_free_despawn_requires_component_context();
+  subagent_despawn_releases_component_capacity_and_allows_archive();
+
+  if (failures != 0) {
+    fprintf(stderr, "%d character runtime test failure(s)\n", failures);
+    return 1;
+  }
+
+  puts("character runtime tests passed");
+  return 0;
+}

--- a/tests/test_imported_catalog_mapper.c
+++ b/tests/test_imported_catalog_mapper.c
@@ -95,6 +95,7 @@ static void narrows_mixed_host_targets(void) {
   CHECK(result.outcome == CORTEX_IMPORT_OUTCOME_NARROWED);
   CHECK(result.surface == CORTEX_IMPORT_SURFACE_HELPER_SUBAGENT_DEFINITION);
   CHECK(result.error == CORTEX_IMPORT_OK);
+  CHECK(result.can_bind_as_subagent == 1u);
   CHECK(strcmp(result.rule_id, "host_targets_narrowed") == 0);
   CHECK(strcmp(cortex_import_outcome_name(result.outcome), "narrowed") == 0);
 }


### PR DESCRIPTION
## Summary
- adds the first native Character/AraComponent/SubagentInstance lifecycle runtime slice for CORTEX#21
- adds public C ABI descriptors/enums for character, component, subagent state, control verbs, runtime errors, and validation output
- implements validation for two- and three-component ARAs, duplicate slot rejection, required role checks, owner checks, parent-state guards, archive safeguards, and component/subagent lifecycle transitions
- integrates the #19 imported mapper by allowing imported helpers to become runtime-relevant only through governed SubagentInstance binding under an eligible AraComponent
- keeps narrowed helper mappings bindable after successful host-target narrowing and tests that end-to-end path

## Verification
- cmake -S . -B "$env:LOCALAPPDATA\CORTEX\character-runtime-build"
- cmake --build "$env:LOCALAPPDATA\CORTEX\character-runtime-build" --config Debug
- ctest --test-dir "$env:LOCALAPPDATA\CORTEX\character-runtime-build" -C Debug --output-on-failure
- git diff --check -- CMakeLists.txt include src tests
- code review found subagent capacity and lifecycle verb gaps; both were fixed and retested

Closes #21
Updates #2
