### PR TITLE
Update CORTEX post-21 progress surfaces

### DIFF
--- a/README.md
+++ b/README.md
@@ -33,17 +33,17 @@ The native core owns character modeling, ARA behavior, lifecycle control, subage
 
 See [docs/character-ara-doctrine.md](docs/character-ara-doctrine.md) for the character model and [docs/native-c-avalonia-direction.md](docs/native-c-avalonia-direction.md) for the stack rule and packaging implications.
 
-## Native runtime slice
+## Native runtime slices
 
-The first native C runtime slice is the imported catalog mapper for `CORTEX #19`.
+The first native C runtime slices are the imported catalog mapper for `CORTEX #19` and the character/ARA lifecycle core for `CORTEX #21`.
 
 ```powershell
-cmake -S . -B "$env:LOCALAPPDATA\CORTEX\imported-catalog-build"
-cmake --build "$env:LOCALAPPDATA\CORTEX\imported-catalog-build" --config Debug
-ctest --test-dir "$env:LOCALAPPDATA\CORTEX\imported-catalog-build" -C Debug --output-on-failure
+cmake -S . -B "$env:LOCALAPPDATA\CORTEX\runtime-build"
+cmake --build "$env:LOCALAPPDATA\CORTEX\runtime-build" --config Debug
+ctest --test-dir "$env:LOCALAPPDATA\CORTEX\runtime-build" -C Debug --output-on-failure
 ```
 
-The current native entry point is [include/cortex/imported_catalog_mapper.h](include/cortex/imported_catalog_mapper.h). It exposes the mapper ABI version, descriptor version, imported catalog registration input, mapping result output, stable outcome/error enums, and the subagent bind capacity guard.
+The current native entry points are [include/cortex/imported_catalog_mapper.h](include/cortex/imported_catalog_mapper.h) and [include/cortex/character_runtime.h](include/cortex/character_runtime.h). They expose the mapper ABI, character/runtime ABI, lifecycle state/actions, stable outcome/error enums, governed imported-helper binding, and subagent capacity guards.
 
 ## Current specification set
 
@@ -63,9 +63,10 @@ The current native entry point is [include/cortex/imported_catalog_mapper.h](inc
 - `CORTEX #3`: Done
 - `CORTEX #9`: Done
 - `CORTEX #19`: Done
-- `CORTEX #21`: Next (native character and ARA lifecycle core)
-- `CORTEX #2`: In Progress (execution sequencing and PRISM wave entry)
+- `CORTEX #21`: Done
+- `CORTEX #24`: Next (live catalog ingestion and runtime persistence)
+- `CORTEX #2`: Done
 
 ## Functional readiness
 
-CORTEX is roughly 22% complete toward a usable runnable product. The contract set, static progress prototype, and first native C mapper/test slice are in place, but broader character runtime, persistence, live catalog ingestion, complete lifecycle execution, and shell integration are still under implementation.
+CORTEX is roughly 30% complete toward a usable runnable product. The contract set, static progress prototype, native imported catalog mapper, and native character/ARA lifecycle core are in place with executable tests, but durable persistence, live catalog ingestion, shell integration, and installable packaging are still open.

--- a/prototypes/cortex-control-surface.html
+++ b/prototypes/cortex-control-surface.html
@@ -481,16 +481,16 @@
             <span>Native imported catalog mapper enforcement is landed and tested.</span>
           </div>
           <div class="metric">
-            <strong>#21 Next</strong>
-            <span>Native character and ARA lifecycle ownership is the next runtime lane.</span>
+            <strong>#21 Done</strong>
+            <span>Native character and ARA lifecycle ownership is landed and tested.</span>
           </div>
           <div class="metric">
             <strong>9 / 9 Contract Lanes Done</strong>
             <span>The contract foundation is complete; #19 added the first native runtime enforcement slice.</span>
           </div>
           <div class="metric">
-            <strong>22% Product Ready</strong>
-            <span>The first native mapper slice is merged; broader runtime, persistence, ingestion, and shell integration remain incomplete.</span>
+            <strong>30% Product Ready</strong>
+            <span>Native mapper and character runtime slices are merged; durable ingestion, persistence, shell integration, and packaging remain incomplete.</span>
           </div>
         </div>
         <div class="progress-strip">
@@ -501,7 +501,7 @@
           <div class="progress-track" aria-label="Execution wave progress">
             <span class="progress-fill" style="width: 100%;"></span>
           </div>
-          <p>Done: #6, #5, #10, #4, #11, #7, #8, #3, #9, #19. Next: #21 native character and ARA lifecycle core.</p>
+          <p>Done: #6, #5, #10, #4, #11, #7, #8, #3, #9, #19, #21. Next: #24 live catalog ingestion and runtime persistence.</p>
         </div>
     </section>
 
@@ -557,11 +557,17 @@
             <div class="status-tag done">Done</div>
             <p>Native descriptors, classifier outcomes, stable errors, and validation coverage turn the mapping contract into executable behavior.</p>
           </div>
-          <div class="wave-card current">
+          <div class="wave-card">
             <div class="issue">Issue #21</div>
             <strong>Character and ARA lifecycle core</strong>
+            <div class="status-tag done">Done</div>
+            <p>Native character, component, and subagent lifecycle ownership is now executable runtime behavior.</p>
+          </div>
+          <div class="wave-card current">
+            <div class="issue">Issue #24</div>
+            <strong>Live catalog ingestion and persistence</strong>
             <div class="status-tag queued">Next</div>
-            <p>Native character, component, and subagent lifecycle ownership is the next executable runtime lane.</p>
+            <p>Native runtime state needs durable ingestion, mapped outcome audit records, and reloadable character/component/subagent state.</p>
           </div>
         </div>
       </article>
@@ -608,7 +614,7 @@
           </div>
           <div class="io-card">
             <strong>Project pulse</strong>
-            <p>Issue #19 is done, #21 is next, and the product remains early until the character core, persistence, live ingestion, and shell integration land.</p>
+            <p>Issue #21 is done, #24 is next, and the product remains early until persistence, live ingestion, shell integration, and packaging land.</p>
           </div>
         </div>
       </article>


### PR DESCRIPTION
## Summary
- move repo/prototype progress from #21 Next to #21 Done
- surface #24 as the next functional-product lane for live catalog ingestion and runtime persistence
- update the local build instructions to include both native runtime test targets
- update functional readiness copy to 30% after the merged #21 lifecycle core

## Verification
- cmake -S . -B "$env:LOCALAPPDATA\CORTEX\runtime-build"
- cmake --build "$env:LOCALAPPDATA\CORTEX\runtime-build" --config Debug
- ctest --test-dir "$env:LOCALAPPDATA\CORTEX\runtime-build" -C Debug --output-on-failure
- git diff --check
