### PR TITLE
CORTEX: install native host artifacts

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -8,6 +8,7 @@ project(CORTEX
 set(CMAKE_C_STANDARD 11)
 set(CMAKE_C_STANDARD_REQUIRED ON)
 set(CMAKE_C_EXTENSIONS OFF)
+include(GNUInstallDirs)
 
 add_library(cortex_imported_catalog_mapper STATIC
   src/imported_catalog_mapper.c)
@@ -134,3 +135,13 @@ add_test(NAME cortex_host_invalid_catalog_fails
     ${CMAKE_CURRENT_BINARY_DIR}/cortex_host_invalid.state)
 set_tests_properties(cortex_host_invalid_catalog_fails
   PROPERTIES WILL_FAIL TRUE)
+
+install(TARGETS cortex_imported_catalog_mapper cortex_character_runtime cortex_runtime_persistence cortex_host
+  RUNTIME DESTINATION ${CMAKE_INSTALL_BINDIR}
+  ARCHIVE DESTINATION ${CMAKE_INSTALL_LIBDIR}
+  LIBRARY DESTINATION ${CMAKE_INSTALL_LIBDIR})
+
+install(FILES include/cortex/imported_catalog_mapper.h
+  include/cortex/character_runtime.h
+  include/cortex/runtime_persistence.h
+  DESTINATION ${CMAKE_INSTALL_INCLUDEDIR}/cortex)


### PR DESCRIPTION
﻿## Summary
- Adds CMake install rules for the CORTEX native host, static runtime libraries, and public headers.
- Aligns CORTEX packaging with the VECTOR install surface so installed CORTEX/VECTOR smoke tests can run from deployed artifacts instead of build-tree binaries.

## Verification
- `cmake -S C:\KHYRON\apps\CORTEX -B $env:LOCALAPPDATA\CORTEX\native-install-surface-build`
- `cmake --build $env:LOCALAPPDATA\CORTEX\native-install-surface-build --config Debug`
- `ctest --test-dir $env:LOCALAPPDATA\CORTEX\native-install-surface-build --output-on-failure -C Debug` -> 10/10 passed
- `cmake --install $env:LOCALAPPDATA\CORTEX\native-install-surface-build --config Debug --prefix $env:LOCALAPPDATA\CORTEX\install-smoke`
- Installed CORTEX host generated a demo state and installed VECTOR host assigned it successfully with `status=ok`, `program=vector-tool-execution-program`, `helper=host-demo-helper`, `character=character-alpha`, `component=component-active`, `subagent=subagent-host-demo`.
